### PR TITLE
[codex] Fix README install and top section

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,46 @@
 
 # `Aki`
 
-Real-time [ASCII](https://en.wikipedia.org/wiki/ASCII) [privacy filter](https://www.reddit.com/r/buildapc/comments/wf46j0/privacy_filter_as_a_software/) for [screen capture](https://dictionary.cambridge.org/dictionary/english/screen-sharing) and [livestreaming](https://en.wikipedia.org/wiki/Live_streaming). 
+`Aki` is a local-first real-time privacy filter for screen sharing and livestreaming. It reads screen pixels, uses OCR and pattern matching to find secrets or PII, then redacts detected regions before the frame leaves through a virtual camera or MJPEG output.
 
-## How does `Aki` do it?
+Because `Aki` works on pixels instead of browser DOM nodes, it can cover terminals, editors, design tools, documents, and other app surfaces where DOM-based blur extensions cannot reliably inspect content.
 
-`Aki` [ingests](#architecture) a live video stream, detects [sensitive information](#block-list) in captured frames via OCR, [transforms](#transformations) sensitive regions using configurable effects, then [outputs](#architecture) the sanitized feed to a virtual camera for use with [OBS or other streaming software](#output-support).
+## Install
 
-For more details, see [here](#nerd-stuff).
+The current primary path is a source install. A signed macOS app and Homebrew cask are planned, but not published yet.
+
+```console
+$ brew install rust tesseract
+$ git clone https://github.com/gongahkia/aki
+$ cd aki
+$ cargo install --path privacy-tui
+$ aki self-test
+$ aki run
+```
+
+If you do not want to install the binary yet, run the TUI directly from the workspace:
+
+```console
+$ cargo run -p privacy-tui -- run
+```
+
+## Quick Commands
+
+```console
+$ aki list-windows
+$ aki test-patterns "SECRET_KEY=abc123"
+$ aki check-output
+$ aki --headless
+```
+
+## Power-User / Developer Commands
+
+```console
+$ cargo run -p privacy-tui -- run
+$ cargo run -p privacy-tui -- --pty
+$ cargo run -p privacy-tui -- test-screen
+$ cargo run -p privacy-tui -- self-test
+```
 
 ## Screenshots
 
@@ -27,25 +60,7 @@ For more details, see [here](#nerd-stuff).
 
 ## Usage
 
-The below instructions are for locally running `Aki`.
-
-1. First install `Aki` locally with the following commands.
-
-```console
-$ git clone https://github.com/gongahkia/aki && cd aki
-$ 
-```
-
-2. Then run the below commands to use `Aki`'s core functionality.
-
-```console
-$ cargo run -- run # run with TUI
-$ cargo run -- list-windows # list available windows
-$ cargo run -- test-patterns "SECRET_KEY=abc123" # test sensitivity patterns against text input
-$ cargo run -- check-output # verify virtual camera availability
-```
-
-3. Once inside `Aki`'s TUI, use the below keybinds.
+Once inside `Aki`'s TUI, use the below keybinds.
 
 | Key | Action |
 |-----|--------|

--- a/privacy-core/src/capture/linux/wayland.rs
+++ b/privacy-core/src/capture/linux/wayland.rs
@@ -112,8 +112,9 @@ impl WaylandCaptureSource {
                     }
                     // width/height from spa_video_info requires format negotiation;
                     // using chunk stride as placeholder until proper SPA format parsing
-                    let w = if stride > 0 { stride / 4 } else { 0 };
-                    let h = if w > 0 { rgba.len() as u32 / 4 / w } else { 0 };
+                    let w = stride.checked_div(4).unwrap_or(0);
+                    let pixel_count = (rgba.len() as u32).checked_div(4).unwrap_or(0);
+                    let h = pixel_count.checked_div(w).unwrap_or(0);
                     if w == 0 || h == 0 {
                         return;
                     }

--- a/privacy-core/src/transform/ascii.rs
+++ b/privacy-core/src/transform/ascii.rs
@@ -40,7 +40,7 @@ pub fn apply_ascii(pixels: &mut [u8], width: u32, height: u32, intensity: f32) {
                     count += 1;
                 }
             }
-            let avg_lum = if count > 0 { lum_sum / count } else { 0 };
+            let avg_lum = lum_sum.checked_div(count).unwrap_or(0);
 
             // map luminance → ramp index → grayscale fill value
             let ramp_idx = (avg_lum as usize * (RAMP_LEN - 1) / 255).min(RAMP_LEN - 1);

--- a/privacy-tui/src/ui/braille.rs
+++ b/privacy-tui/src/ui/braille.rs
@@ -112,10 +112,13 @@ fn frame_to_braille_lines(
             }
 
             let ch = char::from_u32(BRAILLE_BASE + bits).unwrap_or('⠀');
-            let color = if count > 0 {
-                color_approx_256(avg_r / count, avg_g / count, avg_b / count)
-            } else {
-                Color::DarkGray
+            let color = match (
+                avg_r.checked_div(count),
+                avg_g.checked_div(count),
+                avg_b.checked_div(count),
+            ) {
+                (Some(r), Some(g), Some(b)) => color_approx_256(r, g, b),
+                _ => Color::DarkGray,
             };
             spans.push(Span::styled(ch.to_string(), Style::default().fg(color)));
         }

--- a/privacy-tui/src/ui/stats_overlay.rs
+++ b/privacy-tui/src/ui/stats_overlay.rs
@@ -28,7 +28,7 @@ pub fn render(frame: &mut Frame, app: &App, _area: Rect) {
         .iter()
         .map(|(k, v)| (k, v.total_hits))
         .collect();
-    entries.sort_by(|a, b| b.1.cmp(&a.1));
+    entries.sort_by_key(|(_, hits)| std::cmp::Reverse(*hits));
 
     let items: Vec<ListItem> = entries
         .iter()


### PR DESCRIPTION
## What changed
- Rewrote the README opening around Aki's local pixel/OCR redaction model.
- Added a working source-install path near the top of the README.
- Separated installed-binary quick commands from workspace developer commands.
- Removed the broken empty shell prompt and stale root `cargo run -- run` examples.
- Fixed CI-blocking Clippy warnings surfaced by the Linux workflow.

## Validation
- `cargo run -p privacy-tui -- --help`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all`
- `rg "^\$\s*$|cargo run -- run|git clone https://github.com/gongahkia/aki && cd aki" README.md` returned no matches.

Closes #1