### PR TITLE
[codex] Align README version badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![](https://img.shields.io/badge/aki_1.0.0-passing-green)](https://github.com/gongahkia/aki/releases/tag/1.0.0)
-![](https://github.com/gongahkia/aki/actions/workflows/ci.yml/badge.svg)
+[![Version 0.1.0](https://img.shields.io/badge/version-0.1.0-blue)](./Cargo.toml)
+[![CI](https://github.com/gongahkia/aki/actions/workflows/ci.yml/badge.svg)](https://github.com/gongahkia/aki/actions/workflows/ci.yml)
 
 # `Aki`
 


### PR DESCRIPTION
## What changed
- Replaced the misleading static `aki_1.0.0` badge with a README version badge that matches the workspace version, `0.1.0`.
- Removed the README link to the missing `1.0.0` GitHub Release.
- Linked the CI badge to the actual `ci.yml` workflow page.

## Validation
- `gh release view 1.0.0 --json tagName,name,url,isDraft,isPrerelease,publishedAt` reports `release not found`, confirming the old release link was misleading.
- `rg -n 'version = "0\.1\.0"|Version 0\.1\.0|releases/tag|1\.0\.0' Cargo.toml README.md` shows README and Cargo agree on `0.1.0` and no README release-tag link remains.
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all`

Closes #2