### PR TITLE
[codex] Add macOS menu bar shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 CLAUDE.md
+macos/AkiMenuBar/.build/

--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ If you do not want to install the binary yet, run the TUI directly from the work
 $ cargo run -p privacy-tui -- run
 ```
 
+### macOS Menu-Bar Shell
+
+`Aki` also includes a SwiftUI menu-bar shell that controls the Rust binary as a sidecar. Build the Rust sidecar first, then launch the menu-bar app:
+
+```console
+$ cargo build -p privacy-tui
+$ AKI_BINARY="$PWD/target/debug/aki" swift run --package-path macos/AkiMenuBar
+```
+
+The menu-bar shell can start and stop the headless redaction pipeline, pause or resume it, switch transforms, choose the capture/output mode used on restart, show redaction/FPS/CPU stats, and open the TUI in Terminal.
+
 ## Quick Commands
 
 ```console

--- a/macos/AkiMenuBar/Package.swift
+++ b/macos/AkiMenuBar/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "AkiMenuBar",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "AkiMenuBar", targets: ["AkiMenuBar"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "AkiMenuBar"
+        )
+    ]
+)

--- a/macos/AkiMenuBar/Sources/AkiMenuBar/App/AkiMenuBarApp.swift
+++ b/macos/AkiMenuBar/Sources/AkiMenuBar/App/AkiMenuBarApp.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+@main
+struct AkiMenuBarApp: App {
+    @StateObject private var controller = AkiMenuController()
+
+    var body: some Scene {
+        MenuBarExtra {
+            AkiMenuView(controller: controller)
+        } label: {
+            Label("Aki", systemImage: controller.isRunning ? "hand.raised.fill" : "hand.raised")
+        }
+        .menuBarExtraStyle(.window)
+    }
+}

--- a/macos/AkiMenuBar/Sources/AkiMenuBar/Models/AkiModels.swift
+++ b/macos/AkiMenuBar/Sources/AkiMenuBar/Models/AkiModels.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+enum CaptureSource: String, CaseIterable, Identifiable {
+    case screen = "Screen capture"
+    case pty = "PTY terminal"
+
+    var id: String { rawValue }
+    var sidecarArguments: [String] {
+        switch self {
+        case .screen:
+            []
+        case .pty:
+            ["--pty"]
+        }
+    }
+}
+
+enum TransformChoice: String, CaseIterable, Identifiable, Codable {
+    case blur = "Blur"
+    case pixelate = "Pixelate"
+    case cartoon = "Cartoon"
+    case ascii = "ASCII"
+    case neural = "Neural"
+
+    var id: String { rawValue }
+    var sidecarValue: String { rawValue.lowercased() }
+}
+
+enum OutputChoice: String, CaseIterable, Identifiable {
+    case auto = "Auto"
+    case coremedia = "Virtual camera"
+    case mjpeg = "MJPEG"
+    case obs = "OBS browser"
+
+    var id: String { rawValue }
+    var sidecarValue: String {
+        switch self {
+        case .auto:
+            "auto"
+        case .coremedia:
+            "coremedia"
+        case .mjpeg:
+            "mjpeg"
+        case .obs:
+            "obs"
+        }
+    }
+}
+
+struct AkiStats: Equatable {
+    var redactions: UInt64 = 0
+    var fps: Double = 0
+    var cpu: Double?
+    var droppedFrames: UInt64 = 0
+
+    var summary: String {
+        let cpuText = cpu.map { "\(Int($0.rounded()))% CPU" } ?? "--% CPU"
+        return "\(redactions) redactions · \(String(format: "%.0f", fps)) fps · \(cpuText)"
+    }
+}
+
+struct ControlStatsResponse: Decodable {
+    let ok: Bool
+    let mode: String?
+    let paused: Bool?
+    let fps: Double?
+    let redactions: UInt64?
+    let droppedFrames: UInt64?
+
+    enum CodingKeys: String, CodingKey {
+        case ok
+        case mode
+        case paused
+        case fps
+        case redactions
+        case droppedFrames = "dropped_frames"
+    }
+}

--- a/macos/AkiMenuBar/Sources/AkiMenuBar/Services/AkiControlClient.swift
+++ b/macos/AkiMenuBar/Sources/AkiMenuBar/Services/AkiControlClient.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+actor AkiControlClient {
+    private let url = URL(string: "ws://127.0.0.1:9877")!
+    private let decoder = JSONDecoder()
+
+    func pause() async throws {
+        _ = try await send(["cmd": "pause"])
+    }
+
+    func resume() async throws {
+        _ = try await send(["cmd": "resume"])
+    }
+
+    func switchMode(_ mode: TransformChoice) async throws {
+        _ = try await send(["cmd": "switch_mode", "mode": mode.sidecarValue])
+    }
+
+    func stats() async throws -> ControlStatsResponse {
+        let data = try await send(["cmd": "get_stats"])
+        return try decoder.decode(ControlStatsResponse.self, from: data)
+    }
+
+    private func send(_ payload: [String: String]) async throws -> Data {
+        let task = URLSession.shared.webSocketTask(with: url)
+        task.resume()
+        defer {
+            task.cancel(with: .goingAway, reason: nil)
+        }
+
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        let text = String(decoding: data, as: UTF8.self)
+        try await task.send(.string(text))
+        let response = try await task.receive()
+
+        switch response {
+        case .data(let data):
+            return data
+        case .string(let text):
+            return Data(text.utf8)
+        @unknown default:
+            throw URLError(.badServerResponse)
+        }
+    }
+}

--- a/macos/AkiMenuBar/Sources/AkiMenuBar/Services/ProcessSampler.swift
+++ b/macos/AkiMenuBar/Sources/AkiMenuBar/Services/ProcessSampler.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+enum ProcessSampler {
+    static func cpuPercent(pid: Int32) -> Double? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/ps")
+        process.arguments = ["-p", "\(pid)", "-o", "%cpu="]
+
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return nil
+        }
+
+        guard process.terminationStatus == 0 else {
+            return nil
+        }
+
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        let raw = String(decoding: data, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+        return Double(raw)
+    }
+}

--- a/macos/AkiMenuBar/Sources/AkiMenuBar/Services/SidecarBinaryResolver.swift
+++ b/macos/AkiMenuBar/Sources/AkiMenuBar/Services/SidecarBinaryResolver.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+struct ResolvedSidecar {
+    let executableURL: URL
+    let leadingArguments: [String]
+
+    func arguments(for runtimeArguments: [String]) -> [String] {
+        leadingArguments + runtimeArguments
+    }
+}
+
+enum SidecarBinaryResolver {
+    static func resolve(environment: [String: String] = ProcessInfo.processInfo.environment) -> ResolvedSidecar {
+        if let configured = environment["AKI_BINARY"], !configured.isEmpty {
+            return ResolvedSidecar(executableURL: URL(fileURLWithPath: configured), leadingArguments: [])
+        }
+
+        if let resourceURL = Bundle.main.resourceURL?.appendingPathComponent("aki"),
+           FileManager.default.isExecutableFile(atPath: resourceURL.path) {
+            return ResolvedSidecar(executableURL: resourceURL, leadingArguments: [])
+        }
+
+        let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let localDebug = cwd.appendingPathComponent("target/debug/aki")
+        if FileManager.default.isExecutableFile(atPath: localDebug.path) {
+            return ResolvedSidecar(executableURL: localDebug, leadingArguments: [])
+        }
+
+        for path in ["/opt/homebrew/bin/aki", "/usr/local/bin/aki"] {
+            if FileManager.default.isExecutableFile(atPath: path) {
+                return ResolvedSidecar(executableURL: URL(fileURLWithPath: path), leadingArguments: [])
+            }
+        }
+
+        return ResolvedSidecar(executableURL: URL(fileURLWithPath: "/usr/bin/env"), leadingArguments: ["aki"])
+    }
+}

--- a/macos/AkiMenuBar/Sources/AkiMenuBar/Services/TerminalLauncher.swift
+++ b/macos/AkiMenuBar/Sources/AkiMenuBar/Services/TerminalLauncher.swift
@@ -1,0 +1,31 @@
+import AppKit
+import Foundation
+
+enum TerminalLauncher {
+    static func openTUI() {
+        let sidecar = SidecarBinaryResolver.resolve()
+        let command = shellCommand(executable: sidecar.executableURL.path, arguments: sidecar.leadingArguments + ["run"])
+        let script = """
+        tell application "Terminal"
+          activate
+          do script "\(escapeAppleScript(command))"
+        end tell
+        """
+        var error: NSDictionary?
+        NSAppleScript(source: script)?.executeAndReturnError(&error)
+    }
+
+    private static func shellCommand(executable: String, arguments: [String]) -> String {
+        ([executable] + arguments).map(shellQuote).joined(separator: " ")
+    }
+
+    private static func shellQuote(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+
+    private static func escapeAppleScript(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+}

--- a/macos/AkiMenuBar/Sources/AkiMenuBar/Stores/AkiMenuController.swift
+++ b/macos/AkiMenuBar/Sources/AkiMenuBar/Stores/AkiMenuController.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+@MainActor
+final class AkiMenuController: ObservableObject {
+    @Published var source: CaptureSource = .screen
+    @Published var transform: TransformChoice = .ascii
+    @Published var output: OutputChoice = .auto
+    @Published private(set) var isRunning = false
+    @Published private(set) var isPaused = false
+    @Published private(set) var stats = AkiStats()
+    @Published private(set) var statusText = "Stopped"
+
+    private var process: Process?
+    private var refreshTask: Task<Void, Never>?
+    private let controlClient = AkiControlClient()
+
+    func start() {
+        guard process == nil else { return }
+
+        let sidecar = SidecarBinaryResolver.resolve()
+        let process = Process()
+        process.executableURL = sidecar.executableURL
+        process.arguments = sidecar.arguments(for: sidecarArguments())
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+        } catch {
+            statusText = "Could not start sidecar"
+            return
+        }
+
+        self.process = process
+        isRunning = true
+        isPaused = false
+        statusText = "Starting"
+        startStatsRefresh()
+    }
+
+    func stop() {
+        refreshTask?.cancel()
+        refreshTask = nil
+
+        if let process {
+            process.terminate()
+            process.waitUntilExit()
+        }
+
+        process = nil
+        isRunning = false
+        isPaused = false
+        stats = AkiStats()
+        statusText = "Stopped"
+    }
+
+    func togglePause() {
+        guard isRunning else { return }
+        Task {
+            do {
+                if isPaused {
+                    try await controlClient.resume()
+                    await MainActor.run {
+                        isPaused = false
+                        statusText = "Running"
+                    }
+                } else {
+                    try await controlClient.pause()
+                    await MainActor.run {
+                        isPaused = true
+                        statusText = "Paused"
+                    }
+                }
+            } catch {
+                await MainActor.run {
+                    statusText = "Control unavailable"
+                }
+            }
+        }
+    }
+
+    func applyTransformSelection() {
+        guard isRunning else { return }
+        let transform = transform
+        Task {
+            do {
+                try await controlClient.switchMode(transform)
+                await refreshStats()
+            } catch {
+                await MainActor.run {
+                    statusText = "Transform pending"
+                }
+            }
+        }
+    }
+
+    func restartIfRunning() {
+        guard isRunning else { return }
+        stop()
+        start()
+    }
+
+    func openTUI() {
+        TerminalLauncher.openTUI()
+    }
+
+    private func sidecarArguments() -> [String] {
+        var args = ["--headless", "--transform", transform.sidecarValue, "--output", output.sidecarValue]
+        args.append(contentsOf: source.sidecarArguments)
+        return args
+    }
+
+    private func startStatsRefresh() {
+        refreshTask?.cancel()
+        refreshTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1))
+                await self?.refreshStats()
+            }
+        }
+    }
+
+    private func refreshStats() async {
+        guard let process else { return }
+
+        if !process.isRunning {
+            await MainActor.run {
+                self.process = nil
+                self.isRunning = false
+                self.isPaused = false
+                self.statusText = "Sidecar exited"
+            }
+            return
+        }
+
+        do {
+            let response = try await controlClient.stats()
+            let cpu = ProcessSampler.cpuPercent(pid: process.processIdentifier)
+            await MainActor.run {
+                isPaused = response.paused ?? isPaused
+                statusText = isPaused ? "Paused" : "Running"
+                stats = AkiStats(
+                    redactions: response.redactions ?? stats.redactions,
+                    fps: response.fps ?? stats.fps,
+                    cpu: cpu,
+                    droppedFrames: response.droppedFrames ?? stats.droppedFrames
+                )
+            }
+        } catch {
+            await MainActor.run {
+                statusText = "Waiting for control server"
+                stats.cpu = ProcessSampler.cpuPercent(pid: process.processIdentifier)
+            }
+        }
+    }
+}

--- a/macos/AkiMenuBar/Sources/AkiMenuBar/Views/AkiMenuView.swift
+++ b/macos/AkiMenuBar/Sources/AkiMenuBar/Views/AkiMenuView.swift
@@ -1,0 +1,119 @@
+import SwiftUI
+
+struct AkiMenuView: View {
+    @ObservedObject var controller: AkiMenuController
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            header
+
+            Divider()
+
+            Picker("Source", selection: sourceBinding) {
+                ForEach(CaptureSource.allCases) { source in
+                    Text(source.rawValue).tag(source)
+                }
+            }
+
+            Picker("Transform", selection: transformBinding) {
+                ForEach(TransformChoice.allCases) { transform in
+                    Text(transform.rawValue).tag(transform)
+                }
+            }
+
+            Picker("Output", selection: outputBinding) {
+                ForEach(OutputChoice.allCases) { output in
+                    Text(output.rawValue).tag(output)
+                }
+            }
+
+            HStack(spacing: 10) {
+                Button {
+                    controller.isRunning ? controller.stop() : controller.start()
+                } label: {
+                    Label(controller.isRunning ? "Stop" : "Start", systemImage: controller.isRunning ? "stop.fill" : "play.fill")
+                }
+
+                Button {
+                    controller.togglePause()
+                } label: {
+                    Label(controller.isPaused ? "Resume" : "Pause", systemImage: controller.isPaused ? "playpause.fill" : "pause.fill")
+                }
+                .disabled(!controller.isRunning)
+
+                Button {
+                    controller.openTUI()
+                } label: {
+                    Label("Open TUI", systemImage: "terminal")
+                }
+            }
+            .buttonStyle(.bordered)
+
+            Divider()
+
+            statsLine
+        }
+        .padding(16)
+        .frame(width: 340)
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Image(systemName: controller.isRunning ? "record.circle.fill" : "circle")
+                .foregroundStyle(controller.isRunning ? .red : .secondary)
+            Text("Aki")
+                .font(.headline)
+            Spacer()
+            Text(controller.statusText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var statsLine: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(controller.stats.summary)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if controller.stats.droppedFrames > 0 {
+                Text("\(controller.stats.droppedFrames) dropped frames")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+            }
+        }
+    }
+
+    private var sourceBinding: Binding<CaptureSource> {
+        Binding(
+            get: { controller.source },
+            set: {
+                controller.source = $0
+                controller.restartIfRunning()
+            }
+        )
+    }
+
+    private var transformBinding: Binding<TransformChoice> {
+        Binding(
+            get: { controller.transform },
+            set: {
+                controller.transform = $0
+                controller.applyTransformSelection()
+            }
+        )
+    }
+
+    private var outputBinding: Binding<OutputChoice> {
+        Binding(
+            get: { controller.output },
+            set: {
+                controller.output = $0
+                controller.restartIfRunning()
+            }
+        )
+    }
+}
+
+#Preview {
+    AkiMenuView(controller: AkiMenuController())
+}

--- a/privacy-tui/src/app.rs
+++ b/privacy-tui/src/app.rs
@@ -410,6 +410,11 @@ impl App {
             if let Ok(mut queue) = ps.detection_events.try_lock() {
                 let events: Vec<_> = queue.drain(..).collect();
                 drop(queue);
+                if !events.is_empty() {
+                    self.control_state
+                        .redaction_count
+                        .fetch_add(events.len() as u64, std::sync::atomic::Ordering::Relaxed);
+                }
                 for event in events {
                     self.heatmap
                         .record_hit(&event.bounds, self.preview_width, self.preview_height);
@@ -422,6 +427,13 @@ impl App {
                     });
                 }
             }
+            self.control_state.actual_fps_milli.store(
+                (self.stats.actual_fps.max(0.0) * 1000.0) as u32,
+                Ordering::Relaxed,
+            );
+            self.control_state
+                .dropped_frames
+                .store(self.stats.dropped_frames, Ordering::Relaxed);
             if let Ok(mut err) = ps.capture_error.try_lock() {
                 if err.is_some() {
                     self.capture_error = err.take();

--- a/privacy-tui/src/control_server.rs
+++ b/privacy-tui/src/control_server.rs
@@ -11,7 +11,7 @@
 use privacy_common::transform::TransformMode;
 use serde_json::json;
 use std::sync::{
-    atomic::{AtomicBool, AtomicUsize, Ordering},
+    atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering},
     Arc, Mutex,
 };
 use tungstenite::{accept, Message};
@@ -27,6 +27,12 @@ pub struct ControlState {
     pub pending_mode: Mutex<Option<TransformMode>>,
     /// Pending pause/resume change (None = no change, Some(bool) = new paused value).
     pub pending_pause: Mutex<Option<bool>>,
+    /// Latest observed pipeline FPS multiplied by 1000.
+    pub actual_fps_milli: AtomicU32,
+    /// Total redaction events observed by the active process.
+    pub redaction_count: AtomicU64,
+    /// Latest dropped-frame count from the active pipeline.
+    pub dropped_frames: AtomicU64,
 }
 
 impl ControlState {
@@ -37,6 +43,9 @@ impl ControlState {
             intensity: Mutex::new(intensity),
             pending_mode: Mutex::new(None),
             pending_pause: Mutex::new(None),
+            actual_fps_milli: AtomicU32::new(0),
+            redaction_count: AtomicU64::new(0),
+            dropped_frames: AtomicU64::new(0),
         })
     }
 }
@@ -147,12 +156,18 @@ fn dispatch(text: &str, state: &ControlState) -> String {
             let mode = *state.transform_mode.lock().unwrap();
             let intensity = *state.intensity.lock().unwrap();
             let paused = state.paused.load(Ordering::SeqCst);
+            let fps = state.actual_fps_milli.load(Ordering::Relaxed) as f32 / 1000.0;
+            let redactions = state.redaction_count.load(Ordering::Relaxed);
+            let dropped_frames = state.dropped_frames.load(Ordering::Relaxed);
             json!({
                 "ok": true,
                 "cmd": "get_stats",
                 "mode": format!("{mode:?}").to_lowercase(),
                 "intensity": intensity,
                 "paused": paused,
+                "fps": fps,
+                "redactions": redactions,
+                "dropped_frames": dropped_frames,
             })
             .to_string()
         }

--- a/privacy-tui/src/main.rs
+++ b/privacy-tui/src/main.rs
@@ -7,8 +7,9 @@ mod tui;
 mod ui;
 
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use event::{is_quit, next_event, Event};
+use privacy_common::transform::TransformMode;
 use std::time::{Duration, Instant};
 
 const TICK_RATE: Duration = Duration::from_millis(100); // 10 Hz
@@ -22,8 +23,46 @@ struct Cli {
     /// Use PTY capture (intercept shell output) instead of screen capture.
     #[arg(long)]
     pty: bool,
+    /// Initial transform mode for sidecar/headless runs.
+    #[arg(long, value_enum)]
+    transform: Option<CliTransform>,
+    /// Output sink preference for sidecar/headless runs.
+    #[arg(long, value_enum)]
+    output: Option<CliOutput>,
+    /// HTTP MJPEG port used when the output sink needs one.
+    #[arg(long, default_value_t = 9876)]
+    http_port: u16,
     #[command(subcommand)]
     command: Option<Command>,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum CliTransform {
+    Blur,
+    Pixelate,
+    Cartoon,
+    Ascii,
+    Neural,
+}
+
+impl From<CliTransform> for TransformMode {
+    fn from(value: CliTransform) -> Self {
+        match value {
+            CliTransform::Blur => TransformMode::Blur,
+            CliTransform::Pixelate => TransformMode::Pixelate,
+            CliTransform::Cartoon => TransformMode::Cartoon,
+            CliTransform::Ascii => TransformMode::Ascii,
+            CliTransform::Neural => TransformMode::Neural,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum CliOutput {
+    Auto,
+    Coremedia,
+    Mjpeg,
+    Obs,
 }
 
 #[derive(Debug, Subcommand)]
@@ -56,7 +95,7 @@ fn main() -> Result<()> {
         cli.command
     );
     if cli.headless {
-        return cmd_headless(cli.pty);
+        return cmd_headless(cli.pty, cli.transform, cli.output, cli.http_port);
     }
     match cli.command.unwrap_or(Command::Run) {
         Command::Run => cmd_run(cli.pty),
@@ -69,14 +108,20 @@ fn main() -> Result<()> {
 }
 
 /// Headless mode: full pipeline without TUI; logs stats to XDG config dir; Ctrl-C to stop.
-fn cmd_headless(use_pty: bool) -> Result<()> {
+fn cmd_headless(
+    use_pty: bool,
+    transform: Option<CliTransform>,
+    output: Option<CliOutput>,
+    http_port: u16,
+) -> Result<()> {
     use crossbeam_channel::bounded;
     use privacy_common::frame::TransformedFrame;
     use privacy_core::{
+        config::AppConfig,
         detection::{default_patterns::default_registry, pii_patterns::pii_patterns},
         pipeline_runner::spawn_pipeline,
     };
-    use privacy_output::{autodetect::detect_best_sink, create_sink};
+    use privacy_output::{autodetect::detect_best_sink, create_sink, SinkKind};
     use std::sync::{
         atomic::{AtomicBool, Ordering},
         Arc, Mutex,
@@ -90,13 +135,30 @@ fn cmd_headless(use_pty: bool) -> Result<()> {
     })
     .unwrap_or_else(|_| log::warn!("failed to set Ctrl-C handler"));
 
-    let sink_kind = detect_best_sink(9876);
+    let sink_kind = match output.unwrap_or(CliOutput::Auto) {
+        CliOutput::Auto => detect_best_sink(http_port),
+        CliOutput::Coremedia => SinkKind::CoreMedia,
+        CliOutput::Mjpeg => SinkKind::HttpMjpeg(http_port),
+        CliOutput::Obs => SinkKind::Obs(http_port),
+    };
     let sink = Arc::new(Mutex::new(create_sink(sink_kind)?));
+    let cfg = AppConfig::load().unwrap_or_default();
+    let initial_mode = transform
+        .map(TransformMode::from)
+        .unwrap_or_else(|| transform_mode_from_config(&cfg.transform.mode));
+    let initial_intensity = cfg.transform.intensity.clamp(0.0, 1.0);
+    let control_state = control_server::ControlState::new(initial_mode, initial_intensity);
+    control_server::spawn(
+        Arc::clone(&control_state),
+        control_server::DEFAULT_CONTROL_PORT,
+    );
     let mut registry = default_registry();
     registry.patterns.extend(pii_patterns());
     let source = create_capture_source(None, use_pty);
     let (out_tx, out_rx) = bounded::<TransformedFrame>(8);
     let handle = spawn_pipeline(source, None, registry, out_tx)?;
+    *handle.state.transform_mode.lock().unwrap() = initial_mode;
+    *handle.state.transform_intensity.lock().unwrap() = initial_intensity;
 
     // stats log path
     let stats_path = {
@@ -117,6 +179,7 @@ fn cmd_headless(use_pty: bool) -> Result<()> {
     let mut last_log = Instant::now();
 
     while running.load(Ordering::SeqCst) {
+        apply_headless_control(&control_state, &handle.state);
         if let Ok(frame) = out_rx.recv_timeout(Duration::from_millis(200)) {
             if let Ok(mut s) = sink.lock() {
                 let _ = s.write_frame(&frame);
@@ -132,6 +195,13 @@ fn cmd_headless(use_pty: bool) -> Result<()> {
                 0.0
             };
             let dropped = handle.state.dropped_frames.load(Ordering::Relaxed);
+            control_state
+                .actual_fps_milli
+                .store((fps.max(0.0) * 1000.0) as u32, Ordering::Relaxed);
+            control_state
+                .dropped_frames
+                .store(dropped, Ordering::Relaxed);
+            drain_headless_detection_events(&control_state, &handle.state);
             let line = format!(
                 "[{}] fps={:.1} frames={} dropped={}\n",
                 chrono::Utc::now().to_rfc3339(),
@@ -155,6 +225,49 @@ fn cmd_headless(use_pty: bool) -> Result<()> {
     handle.shutdown();
     log::info!("headless mode stopped");
     Ok(())
+}
+
+fn transform_mode_from_config(mode: &str) -> TransformMode {
+    match mode {
+        "cartoon" => TransformMode::Cartoon,
+        "ascii" => TransformMode::Ascii,
+        "pixelate" => TransformMode::Pixelate,
+        "neural" => TransformMode::Neural,
+        _ => TransformMode::Blur,
+    }
+}
+
+fn apply_headless_control(
+    control: &control_server::ControlState,
+    state: &privacy_core::pipeline_runner::SharedState,
+) {
+    if let Ok(mut pending) = control.pending_pause.try_lock() {
+        if let Some(paused) = pending.take() {
+            state
+                .paused
+                .store(paused, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+    if let Ok(mut pending) = control.pending_mode.try_lock() {
+        if let Some(mode) = pending.take() {
+            state.begin_mode_transition(mode);
+        }
+    }
+}
+
+fn drain_headless_detection_events(
+    control: &control_server::ControlState,
+    state: &privacy_core::pipeline_runner::SharedState,
+) {
+    if let Ok(mut events) = state.detection_events.try_lock() {
+        let count = events.len() as u64;
+        events.clear();
+        if count > 0 {
+            control
+                .redaction_count
+                .fetch_add(count, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
 }
 
 fn export_session_log(app: &app::App) {


### PR DESCRIPTION
## What changed
- Added a SwiftPM macOS `MenuBarExtra` app under `macos/AkiMenuBar`.
- Added source, transform, and output pickers plus Start/Stop, Pause/Resume, and Open TUI controls.
- Added sidecar process management for the Rust `aki --headless` binary.
- Extended the Rust control server stats with FPS, redaction count, and dropped frames.
- Added headless sidecar flags for initial transform/output/http-port and control-server command consumption.
- Documented how to build and run the menu-bar shell from the repo.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all`
- `swift build --package-path macos/AkiMenuBar`
- `cargo run -p privacy-tui -- --headless --transform ascii --output mjpeg --help`
- Sidecar smoke test: launched `target/debug/aki --headless --pty --transform ascii --output mjpeg`, connected to `ws://127.0.0.1:9877`, verified `get_stats`, `pause`, `switch_mode`, and updated stats response.

Closes #5