### PR TITLE
Define v1 sidecar protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ cargo build -p privacy-tui
 $ AKI_BINARY="$PWD/target/debug/aki" swift run --package-path macos/AkiMenuBar
 ```
 
-The menu-bar shell can start and stop the headless redaction pipeline, pause or resume it, switch transforms, choose the capture/output mode used on restart, show redaction/FPS/CPU stats, and open the TUI in Terminal.
+The menu-bar shell can start and stop the headless redaction pipeline, pause or resume it, switch transforms, choose the capture/output mode used on restart, show redaction/FPS/CPU stats, and open the TUI in Terminal. The v1 sidecar protocol is documented in [`docs/sidecar-protocol.md`](./docs/sidecar-protocol.md).
 
 ## Quick Commands
 
@@ -47,7 +47,7 @@ The menu-bar shell can start and stop the headless redaction pipeline, pause or 
 $ aki list-windows
 $ aki test-patterns "SECRET_KEY=abc123"
 $ aki check-output
-$ aki --headless
+$ aki --headless --source screen
 ```
 
 ## Power-User / Developer Commands

--- a/docs/sidecar-protocol.md
+++ b/docs/sidecar-protocol.md
@@ -1,0 +1,91 @@
+# Aki v1 Sidecar Protocol
+
+## Decision
+
+V1 uses a Rust sidecar process controlled by the SwiftUI menu-bar app:
+
+- Launch/lifecycle channel: Swift starts `aki` as a child process and passes boot-time choices as CLI arguments.
+- Runtime control channel: the sidecar exposes a localhost WebSocket server at `ws://127.0.0.1:9877`.
+- No FFI is used in v1.
+
+This keeps the shipped Rust pipeline as the single implementation, avoids ABI and crash-coupling risk, and lets the Swift shell use `URLSessionWebSocketTask` without native socket glue.
+
+## Launch Contract
+
+The menu-bar app starts the sidecar with:
+
+```console
+aki --headless --source screen|pty --transform blur|pixelate|cartoon|ascii|neural --output auto|coremedia|mjpeg|obs --http-port 9876
+```
+
+`--pty` remains as a compatibility alias for `--source pty`, but the menu-bar app uses `--source` so source selection is explicit.
+
+Start and stop are process lifecycle operations:
+
+- Start: resolve the sidecar binary, spawn the process, then poll the WebSocket stats endpoint until it is ready.
+- Stop: terminate the child process and wait for exit.
+- Unexpected exit: mark the menu-bar status as exited and clear running state.
+
+Source and output selection are launch-time settings in v1. If either changes while the sidecar is running, the menu-bar app restarts the process with the new arguments. Transform selection can change live through the WebSocket control channel.
+
+## WebSocket Messages
+
+Each request is one JSON text message. Each response is one JSON message with `ok: true` on success or `ok: false` plus `error` on failure.
+
+Pause:
+
+```json
+{"cmd":"pause"}
+```
+
+Resume:
+
+```json
+{"cmd":"resume"}
+```
+
+Set transform:
+
+```json
+{"cmd":"set_transform","mode":"ascii"}
+```
+
+Stats:
+
+```json
+{"cmd":"stats"}
+```
+
+Successful stats responses include:
+
+```json
+{
+  "ok": true,
+  "cmd": "stats",
+  "protocol_version": 1,
+  "mode": "ascii",
+  "intensity": 1.0,
+  "paused": false,
+  "source": "screen",
+  "output": "mjpeg:9876",
+  "fps": 29.8,
+  "redactions": 12,
+  "dropped_frames": 0
+}
+```
+
+The control server still accepts the older `switch_mode` and `get_stats` command names for compatibility.
+
+## Errors
+
+Malformed JSON, missing `cmd`, unknown commands, and unknown transform modes return `ok: false` responses. WebSocket connection failures are treated by the Swift shell as a transient startup/control-server-unavailable state while the process is alive.
+
+If the Rust process cannot bind `127.0.0.1:9877`, it logs the bind failure and continues without runtime control. The Swift shell surfaces that as control unavailable because stats polling cannot connect.
+
+## Rejected Alternatives
+
+Stdio JSON-RPC was rejected for v1 because stdout and stderr are already useful for process diagnostics, and multiplexing logs plus control would make failure handling more brittle.
+
+Unix sockets were rejected for v1 because the extra path management, cleanup, and sandbox/notarization questions do not buy enough over a loopback-only WebSocket for a local menu-bar shell.
+
+FFI was rejected for v1 because it would add ABI boundaries, memory ownership concerns, tighter crash coupling, and extra signing/notarization complexity without improving the first release experience.

--- a/macos/AkiMenuBar/Sources/AkiMenuBar/Models/AkiModels.swift
+++ b/macos/AkiMenuBar/Sources/AkiMenuBar/Models/AkiModels.swift
@@ -5,13 +5,18 @@ enum CaptureSource: String, CaseIterable, Identifiable {
     case pty = "PTY terminal"
 
     var id: String { rawValue }
-    var sidecarArguments: [String] {
+
+    var sidecarValue: String {
         switch self {
         case .screen:
-            []
+            "screen"
         case .pty:
-            ["--pty"]
+            "pty"
         }
+    }
+
+    var sidecarArguments: [String] {
+        ["--source", sidecarValue]
     }
 }
 
@@ -61,16 +66,22 @@ struct AkiStats: Equatable {
 
 struct ControlStatsResponse: Decodable {
     let ok: Bool
+    let protocolVersion: Int?
     let mode: String?
     let paused: Bool?
+    let source: String?
+    let output: String?
     let fps: Double?
     let redactions: UInt64?
     let droppedFrames: UInt64?
 
     enum CodingKeys: String, CodingKey {
         case ok
+        case protocolVersion = "protocol_version"
         case mode
         case paused
+        case source
+        case output
         case fps
         case redactions
         case droppedFrames = "dropped_frames"

--- a/macos/AkiMenuBar/Sources/AkiMenuBar/Services/AkiControlClient.swift
+++ b/macos/AkiMenuBar/Sources/AkiMenuBar/Services/AkiControlClient.swift
@@ -13,11 +13,11 @@ actor AkiControlClient {
     }
 
     func switchMode(_ mode: TransformChoice) async throws {
-        _ = try await send(["cmd": "switch_mode", "mode": mode.sidecarValue])
+        _ = try await send(["cmd": "set_transform", "mode": mode.sidecarValue])
     }
 
     func stats() async throws -> ControlStatsResponse {
-        let data = try await send(["cmd": "get_stats"])
+        let data = try await send(["cmd": "stats"])
         return try decoder.decode(ControlStatsResponse.self, from: data)
     }
 

--- a/privacy-tui/src/control_server.rs
+++ b/privacy-tui/src/control_server.rs
@@ -1,11 +1,11 @@
-//! Localhost WebSocket control server — exposes pipeline commands for Stream Deck etc.
+//! Localhost WebSocket control server — exposes pipeline commands for the macOS sidecar shell.
 //!
 //! Listens on ws://127.0.0.1:9877 (default).
 //! JSON protocol:
 //!   → {"cmd":"pause"}
 //!   → {"cmd":"resume"}
-//!   → {"cmd":"switch_mode","mode":"blur|pixelate|cartoon|ascii|neural"}
-//!   → {"cmd":"get_stats"}
+//!   → {"cmd":"set_transform","mode":"blur|pixelate|cartoon|ascii|neural"}
+//!   → {"cmd":"stats"}
 //! Responses are JSON with {"ok":bool,...}.
 
 use privacy_common::transform::TransformMode;
@@ -33,6 +33,10 @@ pub struct ControlState {
     pub redaction_count: AtomicU64,
     /// Latest dropped-frame count from the active pipeline.
     pub dropped_frames: AtomicU64,
+    /// Capture source selected when the active sidecar process was launched.
+    source: Mutex<String>,
+    /// Output sink selected when the active sidecar process was launched.
+    output: Mutex<String>,
 }
 
 impl ControlState {
@@ -46,7 +50,17 @@ impl ControlState {
             actual_fps_milli: AtomicU32::new(0),
             redaction_count: AtomicU64::new(0),
             dropped_frames: AtomicU64::new(0),
+            source: Mutex::new("screen".to_string()),
+            output: Mutex::new("auto".to_string()),
         })
+    }
+
+    pub fn set_source(&self, source: &str) {
+        *self.source.lock().unwrap() = source.to_string();
+    }
+
+    pub fn set_output(&self, output: &str) {
+        *self.output.lock().unwrap() = output.to_string();
     }
 }
 
@@ -139,32 +153,42 @@ fn dispatch(text: &str, state: &ControlState) -> String {
             *state.pending_pause.lock().unwrap() = Some(false);
             json!({"ok":true,"cmd":"resume"}).to_string()
         }
-        Some("switch_mode") => {
+        Some("switch_mode") | Some("set_transform") => {
+            let cmd = v
+                .get("cmd")
+                .and_then(|c| c.as_str())
+                .unwrap_or("set_transform");
             let mode_str = v.get("mode").and_then(|m| m.as_str()).unwrap_or("");
             match parse_mode(mode_str) {
                 Some(mode) => {
-                    log::info!("control server: cmd=switch_mode mode={mode_str}");
+                    log::info!("control server: cmd={cmd} mode={mode_str}");
                     *state.transform_mode.lock().unwrap() = mode;
                     *state.pending_mode.lock().unwrap() = Some(mode);
-                    json!({"ok":true,"cmd":"switch_mode","mode":mode_str}).to_string()
+                    json!({"ok":true,"cmd":cmd,"mode":mode_label(mode)}).to_string()
                 }
                 None => json!({"ok":false,"error":format!("unknown mode: {mode_str}")}).to_string(),
             }
         }
-        Some("get_stats") => {
-            log::debug!("control server: cmd=get_stats");
+        Some("get_stats") | Some("stats") => {
+            let cmd = v.get("cmd").and_then(|c| c.as_str()).unwrap_or("stats");
+            log::debug!("control server: cmd={cmd}");
             let mode = *state.transform_mode.lock().unwrap();
             let intensity = *state.intensity.lock().unwrap();
             let paused = state.paused.load(Ordering::SeqCst);
             let fps = state.actual_fps_milli.load(Ordering::Relaxed) as f32 / 1000.0;
             let redactions = state.redaction_count.load(Ordering::Relaxed);
             let dropped_frames = state.dropped_frames.load(Ordering::Relaxed);
+            let source = state.source.lock().unwrap().clone();
+            let output = state.output.lock().unwrap().clone();
             json!({
                 "ok": true,
-                "cmd": "get_stats",
-                "mode": format!("{mode:?}").to_lowercase(),
+                "cmd": cmd,
+                "protocol_version": 1,
+                "mode": mode_label(mode),
                 "intensity": intensity,
                 "paused": paused,
+                "source": source,
+                "output": output,
                 "fps": fps,
                 "redactions": redactions,
                 "dropped_frames": dropped_frames,
@@ -190,5 +214,15 @@ fn parse_mode(s: &str) -> Option<TransformMode> {
         "ascii" => Some(TransformMode::Ascii),
         "neural" => Some(TransformMode::Neural),
         _ => None,
+    }
+}
+
+fn mode_label(mode: TransformMode) -> &'static str {
+    match mode {
+        TransformMode::Blur => "blur",
+        TransformMode::Pixelate => "pixelate",
+        TransformMode::Cartoon => "cartoon",
+        TransformMode::Ascii => "ascii",
+        TransformMode::Neural => "neural",
     }
 }

--- a/privacy-tui/src/main.rs
+++ b/privacy-tui/src/main.rs
@@ -6,7 +6,7 @@ mod shutdown;
 mod tui;
 mod ui;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 use event::{is_quit, next_event, Event};
 use privacy_common::transform::TransformMode;
@@ -20,7 +20,10 @@ struct Cli {
     /// Run without TUI (headless mode) — log stats to file, output to virtual camera only.
     #[arg(long)]
     headless: bool,
-    /// Use PTY capture (intercept shell output) instead of screen capture.
+    /// Capture source for sidecar/headless runs.
+    #[arg(long, value_enum)]
+    source: Option<CliSource>,
+    /// Use PTY capture (compatibility alias for --source pty).
     #[arg(long)]
     pty: bool,
     /// Initial transform mode for sidecar/headless runs.
@@ -43,6 +46,25 @@ enum CliTransform {
     Cartoon,
     Ascii,
     Neural,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum CliSource {
+    Screen,
+    Pty,
+}
+
+impl CliSource {
+    fn uses_pty(self) -> bool {
+        matches!(self, CliSource::Pty)
+    }
+
+    fn protocol_value(self) -> &'static str {
+        match self {
+            CliSource::Screen => "screen",
+            CliSource::Pty => "pty",
+        }
+    }
 }
 
 impl From<CliTransform> for TransformMode {
@@ -88,17 +110,18 @@ fn main() -> Result<()> {
     let log_path = logging::init()?;
     log::info!("log file ready at {}", log_path.display());
     let cli = Cli::parse();
+    let source = resolve_source(cli.source, cli.pty)?;
     log::info!(
-        "cli parsed headless={} pty={} command={:?}",
+        "cli parsed headless={} source={} command={:?}",
         cli.headless,
-        cli.pty,
+        source.protocol_value(),
         cli.command
     );
     if cli.headless {
-        return cmd_headless(cli.pty, cli.transform, cli.output, cli.http_port);
+        return cmd_headless(source, cli.transform, cli.output, cli.http_port);
     }
     match cli.command.unwrap_or(Command::Run) {
-        Command::Run => cmd_run(cli.pty),
+        Command::Run => cmd_run(source.uses_pty()),
         Command::ListWindows => cmd_list_windows(),
         Command::TestPatterns { text } => cmd_test_patterns(&text),
         Command::CheckOutput => cmd_check_output(),
@@ -107,9 +130,18 @@ fn main() -> Result<()> {
     }
 }
 
+fn resolve_source(source: Option<CliSource>, pty: bool) -> Result<CliSource> {
+    match (source, pty) {
+        (Some(CliSource::Screen), true) => bail!("--source screen cannot be combined with --pty"),
+        (Some(source), _) => Ok(source),
+        (None, true) => Ok(CliSource::Pty),
+        (None, false) => Ok(CliSource::Screen),
+    }
+}
+
 /// Headless mode: full pipeline without TUI; logs stats to XDG config dir; Ctrl-C to stop.
 fn cmd_headless(
-    use_pty: bool,
+    source_choice: CliSource,
     transform: Option<CliTransform>,
     output: Option<CliOutput>,
     http_port: u16,
@@ -127,7 +159,10 @@ fn cmd_headless(
         Arc, Mutex,
     };
 
-    log::info!("starting headless mode use_pty={use_pty}");
+    log::info!(
+        "starting headless mode source={}",
+        source_choice.protocol_value()
+    );
     let running = Arc::new(AtomicBool::new(true));
     let r = running.clone();
     ctrlc::set_handler(move || {
@@ -135,12 +170,14 @@ fn cmd_headless(
     })
     .unwrap_or_else(|_| log::warn!("failed to set Ctrl-C handler"));
 
-    let sink_kind = match output.unwrap_or(CliOutput::Auto) {
+    let output_choice = output.unwrap_or(CliOutput::Auto);
+    let sink_kind = match output_choice {
         CliOutput::Auto => detect_best_sink(http_port),
         CliOutput::Coremedia => SinkKind::CoreMedia,
         CliOutput::Mjpeg => SinkKind::HttpMjpeg(http_port),
         CliOutput::Obs => SinkKind::Obs(http_port),
     };
+    let output_label = sink_kind_label(&sink_kind);
     let sink = Arc::new(Mutex::new(create_sink(sink_kind)?));
     let cfg = AppConfig::load().unwrap_or_default();
     let initial_mode = transform
@@ -148,13 +185,15 @@ fn cmd_headless(
         .unwrap_or_else(|| transform_mode_from_config(&cfg.transform.mode));
     let initial_intensity = cfg.transform.intensity.clamp(0.0, 1.0);
     let control_state = control_server::ControlState::new(initial_mode, initial_intensity);
+    control_state.set_source(source_choice.protocol_value());
+    control_state.set_output(&output_label);
     control_server::spawn(
         Arc::clone(&control_state),
         control_server::DEFAULT_CONTROL_PORT,
     );
     let mut registry = default_registry();
     registry.patterns.extend(pii_patterns());
-    let source = create_capture_source(None, use_pty);
+    let source = create_capture_source(None, source_choice.uses_pty());
     let (out_tx, out_rx) = bounded::<TransformedFrame>(8);
     let handle = spawn_pipeline(source, None, registry, out_tx)?;
     *handle.state.transform_mode.lock().unwrap() = initial_mode;
@@ -225,6 +264,16 @@ fn cmd_headless(
     handle.shutdown();
     log::info!("headless mode stopped");
     Ok(())
+}
+
+fn sink_kind_label(sink_kind: &privacy_output::SinkKind) -> String {
+    match sink_kind {
+        privacy_output::SinkKind::V4l2(path) => format!("v4l2:{path}"),
+        privacy_output::SinkKind::CoreMedia => "coremedia".to_string(),
+        privacy_output::SinkKind::HttpMjpeg(port) => format!("mjpeg:{port}"),
+        privacy_output::SinkKind::Obs(port) => format!("obs:{port}"),
+        privacy_output::SinkKind::Twitch => "twitch".to_string(),
+    }
 }
 
 fn transform_mode_from_config(mode: &str) -> TransformMode {


### PR DESCRIPTION
## Summary
- documents the v1 Rust sidecar protocol decision and rejected alternatives
- adds explicit --source screen|pty launch support while keeping --pty compatibility
- updates the WebSocket protocol with set_transform/stats aliases and stats source/output metadata
- updates the Swift menu-bar shell to use the explicit source flag and new command names

Closes #6

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test --all
- cargo build -p privacy-tui
- swift build --package-path macos/AkiMenuBar
- sidecar WebSocket smoke test for stats, set_transform, pause, and legacy get_stats