### PR TITLE
Add macOS DMG release workflow

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,0 +1,75 @@
+name: Aki macOS release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to package, for example 0.1.0
+        required: true
+        type: string
+      tag:
+        description: Git tag or release name, for example v0.1.0
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install native dependencies
+        run: brew install tesseract libarchive
+
+      - name: Import Developer ID certificate
+        env:
+          CERT_P12_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION_CERT_P12_BASE64 }}
+          CERT_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION_CERT_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          test -n "$CERT_P12_BASE64"
+          test -n "$CERT_PASSWORD"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build-signing.keychain
+          security set-keychain-settings -lut 21600 build-signing.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build-signing.keychain
+          echo "$CERT_P12_BASE64" | base64 --decode > developer-id.p12
+          security import developer-id.p12 \
+            -k build-signing.keychain \
+            -P "$CERT_PASSWORD" \
+            -T /usr/bin/codesign
+          security list-keychains -d user -s build-signing.keychain login.keychain
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s \
+            -k "$KEYCHAIN_PASSWORD" \
+            build-signing.keychain
+
+      - name: Build signed notarized DMG
+        env:
+          AKI_VERSION: ${{ inputs.version }}
+          AKI_SIGN_IDENTITY: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION_IDENTITY }}
+          AKI_NOTARY_APPLE_ID: ${{ secrets.AKI_NOTARY_APPLE_ID }}
+          AKI_NOTARY_TEAM_ID: ${{ secrets.AKI_NOTARY_TEAM_ID }}
+          AKI_NOTARY_PASSWORD: ${{ secrets.AKI_NOTARY_PASSWORD }}
+        run: scripts/release_macos_dmg.sh --version "$AKI_VERSION"
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          DMG="dist/macos/Aki-${VERSION}-macos.dmg"
+          SHA="${DMG}.sha256"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" "$DMG" "$SHA" --clobber
+          else
+            gh release create "$TAG" "$DMG" "$SHA" \
+              --title "Aki ${VERSION}" \
+              --generate-notes
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
+/dist
 CLAUDE.md
 macos/AkiMenuBar/.build/

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ $ AKI_BINARY="$PWD/target/debug/aki" swift run --package-path macos/AkiMenuBar
 
 The menu-bar shell can start and stop the headless redaction pipeline, pause or resume it, switch transforms, choose the capture/output mode used on restart, show redaction/FPS/CPU stats, and open the TUI in Terminal. The v1 sidecar protocol is documented in [`docs/sidecar-protocol.md`](./docs/sidecar-protocol.md).
 
+macOS DMG release packaging is documented in [`docs/macos-release.md`](./docs/macos-release.md).
+
 ## Quick Commands
 
 ```console

--- a/docs/macos-release.md
+++ b/docs/macos-release.md
@@ -1,0 +1,88 @@
+# macOS Release Process
+
+This process builds the SwiftUI menu-bar app, embeds the Rust `aki` sidecar, vendors non-system dylib dependencies, signs the bundle, notarizes it with Apple, staples tickets, and creates a DMG.
+
+## Prerequisites
+
+Install local build dependencies:
+
+```console
+$ brew install rust tesseract libarchive
+```
+
+The signed release path requires:
+
+- A Developer ID Application certificate in the signing keychain.
+- Apple notarization credentials, preferably stored as a `notarytool` keychain profile.
+- Xcode command line tools with `codesign`, `hdiutil`, `stapler`, and `notarytool`.
+
+The current development machine only has an Apple Development identity. That can build and run locally, but it cannot produce a Gatekeeper-clean public DMG. Public releases must use a Developer ID Application identity.
+
+## Local Unsigned Validation
+
+Use this to verify bundle layout, dylib vendoring, install-name rewriting, and DMG creation without Apple credentials:
+
+```console
+$ scripts/release_macos_dmg.sh --unsigned
+```
+
+This produces an ad-hoc-signed local test artifact under `dist/macos/`. It is not a release artifact and will not satisfy Gatekeeper for downloaded distribution.
+
+## Signed And Notarized Release
+
+Use either a keychain profile:
+
+```console
+$ export AKI_SIGN_IDENTITY="Developer ID Application: Example Name (TEAMID)"
+$ export AKI_NOTARY_KEYCHAIN_PROFILE="aki-notary"
+$ scripts/release_macos_dmg.sh --version 0.1.0
+```
+
+Or pass notary credentials through environment variables:
+
+```console
+$ export AKI_SIGN_IDENTITY="Developer ID Application: Example Name (TEAMID)"
+$ export AKI_NOTARY_APPLE_ID="apple-id@example.com"
+$ export AKI_NOTARY_TEAM_ID="TEAMID"
+$ export AKI_NOTARY_PASSWORD="app-specific-password"
+$ scripts/release_macos_dmg.sh --version 0.1.0
+```
+
+The script writes:
+
+- `dist/macos/Aki-<version>-macos.dmg`
+- `dist/macos/Aki-<version>-macos.dmg.sha256`
+
+## What The Script Verifies
+
+The release script:
+
+- Builds `privacy-tui` in release mode.
+- Builds `macos/AkiMenuBar` in release mode.
+- Creates `Aki.app` with `AkiMenuBar` in `Contents/MacOS/` and the Rust sidecar in `Contents/Resources/aki`.
+- Recursively copies Homebrew-linked dylibs into `Contents/Frameworks/`.
+- Rewrites copied dylib install names to `@executable_path/../Frameworks/...` for the sidecar.
+- Signs dylibs, the sidecar, the Swift executable, the app bundle, and the DMG.
+- Notarizes and staples the app bundle and the DMG.
+- Runs `codesign --verify`, `xcrun stapler validate`, and `spctl --assess`.
+
+## GitHub Release Workflow
+
+The manual workflow at `.github/workflows/release-macos.yml` packages and uploads the DMG to a GitHub Release. Required secrets:
+
+- `MACOS_DEVELOPER_ID_APPLICATION_CERT_P12_BASE64`
+- `MACOS_DEVELOPER_ID_APPLICATION_CERT_PASSWORD`
+- `MACOS_DEVELOPER_ID_APPLICATION_IDENTITY`
+- `AKI_NOTARY_APPLE_ID`
+- `AKI_NOTARY_TEAM_ID`
+- `AKI_NOTARY_PASSWORD`
+
+The workflow creates or updates the requested GitHub Release and uploads the DMG plus SHA-256 file, so the release notes link directly to the artifact.
+
+## Failure Modes
+
+If `AKI_SIGN_IDENTITY` is missing or is not a Developer ID Application identity, the script fails before creating a public release artifact.
+
+If notarization credentials are missing, the script fails before submission. It does not print notary passwords.
+
+If a Homebrew-linked dylib is missing during dependency vendoring, the script fails instead of creating a DMG that would break on a stock Mac.

--- a/scripts/release_macos_dmg.sh
+++ b/scripts/release_macos_dmg.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Build, package, sign, notarize, staple, and verify the macOS Aki DMG.
+
+Usage:
+  scripts/release_macos_dmg.sh [--version VERSION] [--skip-notarize] [--unsigned]
+
+Environment for signed releases:
+  AKI_SIGN_IDENTITY             Developer ID Application identity name.
+  AKI_NOTARY_KEYCHAIN_PROFILE   Optional notarytool keychain profile.
+
+Or, instead of AKI_NOTARY_KEYCHAIN_PROFILE:
+  AKI_NOTARY_APPLE_ID           Apple ID for notarytool.
+  AKI_NOTARY_TEAM_ID            Apple Developer Team ID.
+  AKI_NOTARY_PASSWORD           App-specific password.
+
+Options:
+  --version VERSION   Override version from Cargo.toml.
+  --skip-notarize     Sign and create the DMG, but do not submit to Apple.
+  --unsigned          Ad-hoc sign for local bundle/DMG smoke tests only.
+  --help              Show this help.
+EOF
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+log() {
+  echo "==> $*"
+}
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="${AKI_VERSION:-}"
+SKIP_NOTARIZE=0
+UNSIGNED=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      [[ $# -ge 2 ]] || die "--version requires a value"
+      VERSION="$2"
+      shift 2
+      ;;
+    --skip-notarize)
+      SKIP_NOTARIZE=1
+      shift
+      ;;
+    --unsigned)
+      UNSIGNED=1
+      SKIP_NOTARIZE=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ -z "$VERSION" ]]; then
+  VERSION="$(awk -F '"' '/^version =/ { print $2; exit }' "$ROOT/Cargo.toml")"
+fi
+[[ -n "$VERSION" ]] || die "could not determine version"
+
+APP_NAME="Aki"
+BUNDLE_ID="${AKI_BUNDLE_ID:-dev.gongahkia.aki}"
+DIST_DIR="${AKI_DIST_DIR:-$ROOT/dist/macos}"
+WORK_DIR="$ROOT/target/release/macos-dmg"
+APP="$WORK_DIR/$APP_NAME.app"
+CONTENTS="$APP/Contents"
+MACOS_DIR="$CONTENTS/MacOS"
+RESOURCES_DIR="$CONTENTS/Resources"
+FRAMEWORKS_DIR="$CONTENTS/Frameworks"
+SWIFT_EXE="$ROOT/macos/AkiMenuBar/.build/release/AkiMenuBar"
+SIDECAR_EXE="$ROOT/target/release/aki"
+APP_ZIP="$DIST_DIR/$APP_NAME-$VERSION-macos-app.zip"
+DMG="$DIST_DIR/$APP_NAME-$VERSION-macos.dmg"
+SHA256="$DMG.sha256"
+
+if [[ "$UNSIGNED" -eq 0 ]]; then
+  [[ -n "${AKI_SIGN_IDENTITY:-}" ]] || die "AKI_SIGN_IDENTITY must name a Developer ID Application identity"
+  [[ "$AKI_SIGN_IDENTITY" == *"Developer ID Application"* ]] || die "AKI_SIGN_IDENTITY must be a Developer ID Application identity"
+  security find-identity -v -p codesigning | grep -F "$AKI_SIGN_IDENTITY" >/dev/null \
+    || die "codesigning identity not found in keychain: $AKI_SIGN_IDENTITY"
+
+  if [[ "$SKIP_NOTARIZE" -eq 0 ]]; then
+    if [[ -z "${AKI_NOTARY_KEYCHAIN_PROFILE:-}" ]]; then
+      [[ -n "${AKI_NOTARY_APPLE_ID:-}" ]] || die "AKI_NOTARY_APPLE_ID or AKI_NOTARY_KEYCHAIN_PROFILE is required"
+      [[ -n "${AKI_NOTARY_TEAM_ID:-}" ]] || die "AKI_NOTARY_TEAM_ID or AKI_NOTARY_KEYCHAIN_PROFILE is required"
+      [[ -n "${AKI_NOTARY_PASSWORD:-}" ]] || die "AKI_NOTARY_PASSWORD or AKI_NOTARY_KEYCHAIN_PROFILE is required"
+    fi
+  fi
+fi
+
+sign_path() {
+  local path="$1"
+  if [[ "$UNSIGNED" -eq 1 ]]; then
+    codesign --force --sign - "$path"
+  else
+    codesign --force --timestamp --options runtime --sign "$AKI_SIGN_IDENTITY" "$path"
+  fi
+}
+
+notary_submit() {
+  local archive="$1"
+  [[ "$SKIP_NOTARIZE" -eq 0 ]] || return 0
+
+  if [[ -n "${AKI_NOTARY_KEYCHAIN_PROFILE:-}" ]]; then
+    xcrun notarytool submit "$archive" \
+      --keychain-profile "$AKI_NOTARY_KEYCHAIN_PROFILE" \
+      --wait
+  else
+    xcrun notarytool submit "$archive" \
+      --apple-id "$AKI_NOTARY_APPLE_ID" \
+      --team-id "$AKI_NOTARY_TEAM_ID" \
+      --password "$AKI_NOTARY_PASSWORD" \
+      --wait
+  fi
+}
+
+is_external_dylib() {
+  case "$1" in
+    /opt/homebrew/*|/usr/local/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+external_dylibs_for() {
+  local file="$1"
+  otool -L "$file" | awk 'NR > 1 { print $1 }' | while read -r dep; do
+    if is_external_dylib "$dep"; then
+      printf '%s\n' "$dep"
+    fi
+  done
+}
+
+bundle_external_dylibs() {
+  local queue=("$RESOURCES_DIR/aki")
+  local current dep dest
+
+  while [[ "${#queue[@]}" -gt 0 ]]; do
+    current="${queue[0]}"
+    queue=("${queue[@]:1}")
+
+    while read -r dep; do
+      [[ -z "$dep" ]] && continue
+      [[ -f "$dep" ]] || die "linked dylib is missing: $dep"
+      dest="$FRAMEWORKS_DIR/$(basename "$dep")"
+      if [[ ! -f "$dest" ]]; then
+        log "Bundling $(basename "$dep")"
+        cp "$dep" "$dest"
+        chmod u+w "$dest"
+        queue+=("$dest")
+      fi
+    done < <(external_dylibs_for "$current")
+  done
+}
+
+rewrite_install_names() {
+  local targets=("$RESOURCES_DIR/aki")
+  local target dep rewritten
+
+  while IFS= read -r -d '' target; do
+    targets+=("$target")
+  done < <(find "$FRAMEWORKS_DIR" -type f -name '*.dylib' -print0)
+
+  for target in "${targets[@]}"; do
+    if [[ "$target" == "$FRAMEWORKS_DIR/"* ]]; then
+      install_name_tool -id "@executable_path/../Frameworks/$(basename "$target")" "$target"
+    fi
+
+    while read -r dep; do
+      [[ -z "$dep" ]] && continue
+      rewritten="@executable_path/../Frameworks/$(basename "$dep")"
+      install_name_tool -change "$dep" "$rewritten" "$target"
+    done < <(external_dylibs_for "$target")
+  done
+}
+
+write_info_plist() {
+  cat > "$CONTENTS/Info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleName</key>
+  <string>$APP_NAME</string>
+  <key>CFBundleDisplayName</key>
+  <string>$APP_NAME</string>
+  <key>CFBundleIdentifier</key>
+  <string>$BUNDLE_ID</string>
+  <key>CFBundleExecutable</key>
+  <string>AkiMenuBar</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>$VERSION</string>
+  <key>CFBundleVersion</key>
+  <string>$VERSION</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>13.0</string>
+  <key>LSUIElement</key>
+  <true/>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+</dict>
+</plist>
+EOF
+  printf 'APPL????' > "$CONTENTS/PkgInfo"
+}
+
+log "Building Rust sidecar"
+cargo build --release -p privacy-tui
+
+log "Building Swift menu-bar executable"
+swift build -c release --package-path "$ROOT/macos/AkiMenuBar"
+
+log "Creating app bundle at $APP"
+rm -rf "$WORK_DIR"
+mkdir -p "$MACOS_DIR" "$RESOURCES_DIR" "$FRAMEWORKS_DIR" "$DIST_DIR"
+install -m 755 "$SWIFT_EXE" "$MACOS_DIR/AkiMenuBar"
+install -m 755 "$SIDECAR_EXE" "$RESOURCES_DIR/aki"
+write_info_plist
+
+log "Bundling non-system dylib dependencies"
+bundle_external_dylibs
+rewrite_install_names
+
+log "Signing nested code"
+while IFS= read -r -d '' dylib; do
+  sign_path "$dylib"
+done < <(find "$FRAMEWORKS_DIR" -type f -name '*.dylib' -print0)
+sign_path "$RESOURCES_DIR/aki"
+sign_path "$MACOS_DIR/AkiMenuBar"
+sign_path "$APP"
+codesign --verify --strict --verbose=2 "$APP"
+
+if [[ "$SKIP_NOTARIZE" -eq 0 ]]; then
+  log "Submitting app bundle for notarization"
+  rm -f "$APP_ZIP"
+  ditto -c -k --keepParent "$APP" "$APP_ZIP"
+  notary_submit "$APP_ZIP"
+  xcrun stapler staple "$APP"
+  xcrun stapler validate "$APP"
+fi
+
+log "Creating DMG"
+DMG_ROOT="$WORK_DIR/dmg-root"
+rm -rf "$DMG_ROOT" "$DMG" "$SHA256"
+mkdir -p "$DMG_ROOT"
+ditto "$APP" "$DMG_ROOT/$APP_NAME.app"
+ln -s /Applications "$DMG_ROOT/Applications"
+hdiutil create -volname "$APP_NAME $VERSION" -srcfolder "$DMG_ROOT" -ov -format UDZO "$DMG"
+sign_path "$DMG"
+
+if [[ "$SKIP_NOTARIZE" -eq 0 ]]; then
+  log "Submitting DMG for notarization"
+  notary_submit "$DMG"
+  xcrun stapler staple "$DMG"
+  xcrun stapler validate "$DMG"
+  spctl --assess --type execute --verbose=4 "$APP"
+  spctl --assess --type open --context context:primary-signature --verbose=4 "$DMG"
+fi
+
+shasum -a 256 "$DMG" > "$SHA256"
+log "Wrote $DMG"
+log "Wrote $SHA256"


### PR DESCRIPTION
## Summary
- adds an executable macOS release script that builds Aki.app, embeds the Rust sidecar, vendors Homebrew-linked dylibs, rewrites install names, signs, notarizes, staples, and creates a DMG
- adds a manual GitHub Actions workflow for signed/notarized macOS release artifacts and GitHub Release uploads
- documents local unsigned validation, signed release prerequisites, secret names, verification checks, and safe failure modes
- ignores generated dist/ artifacts and links the release docs from the README

Closes #7

## Validation
- bash -n scripts/release_macos_dmg.sh
- parsed .github/workflows/release-macos.yml with Python YAML loader
- scripts/release_macos_dmg.sh --unsigned produced dist/macos/Aki-0.1.0-macos.dmg and SHA-256 file
- hdiutil verify dist/macos/Aki-0.1.0-macos.dmg
- otool linkage sweep across packaged app executable, sidecar, and 14 vendored dylibs found no /opt/homebrew or /usr/local load commands
- signed-release preflight fails safely without AKI_SIGN_IDENTITY

## Note
This machine only has an Apple Development codesigning identity, not a Developer ID Application identity, so I validated the packaging path in explicit ad-hoc local mode. The default signed/notarized path now requires Developer ID and notary credentials and fails before artifact creation when they are missing.