### PR TITLE
Add Homebrew cask install path

### DIFF
--- a/Casks/aki.rb
+++ b/Casks/aki.rb
@@ -1,0 +1,26 @@
+cask "aki" do
+  version "0.1.0"
+  sha256 :no_check
+
+  url "https://github.com/gongahkia/aki/releases/download/v#{version}/Aki-#{version}-macos.dmg"
+  name "Aki"
+  desc "Local-first real-time privacy filter for screen sharing and livestreaming"
+  homepage "https://github.com/gongahkia/aki"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :ventura
+
+  app "Aki.app"
+
+  uninstall quit: "dev.gongahkia.aki"
+
+  zap trash: [
+    "~/.config/ascii-privacy",
+    "~/Library/Caches/dev.gongahkia.aki",
+    "~/Library/Logs/Aki",
+  ]
+end

--- a/README.md
+++ b/README.md
@@ -13,7 +13,14 @@ Because `Aki` works on pixels instead of browser DOM nodes, it can cover termina
 
 ## Install
 
-The current primary path is a source install. A signed macOS app and Homebrew cask are planned, but not published yet.
+The primary macOS release install path is the Homebrew cask:
+
+```console
+$ brew tap gongahkia/aki
+$ brew install --cask aki
+```
+
+If the signed DMG for the current version has not been published yet, use the source install path:
 
 ```console
 $ brew install rust tesseract
@@ -41,7 +48,7 @@ $ AKI_BINARY="$PWD/target/debug/aki" swift run --package-path macos/AkiMenuBar
 
 The menu-bar shell can start and stop the headless redaction pipeline, pause or resume it, switch transforms, choose the capture/output mode used on restart, show redaction/FPS/CPU stats, and open the TUI in Terminal. The v1 sidecar protocol is documented in [`docs/sidecar-protocol.md`](./docs/sidecar-protocol.md).
 
-macOS DMG release packaging is documented in [`docs/macos-release.md`](./docs/macos-release.md).
+macOS DMG release packaging is documented in [`docs/macos-release.md`](./docs/macos-release.md), and the cask path is documented in [`docs/homebrew-cask.md`](./docs/homebrew-cask.md).
 
 ## Quick Commands
 

--- a/docs/homebrew-cask.md
+++ b/docs/homebrew-cask.md
@@ -1,0 +1,70 @@
+# Homebrew Cask
+
+## Tap Decision
+
+V1 uses the project repository as the tap:
+
+```console
+$ brew tap gongahkia/aki
+```
+
+This keeps the cask, release workflow, source code, and release docs in one repository while Aki has a single app artifact. If Aki later ships multiple tools, the tap can move to `gongahkia/tap`.
+
+## Install
+
+After a signed and notarized GitHub Release DMG exists for the current cask version:
+
+```console
+$ brew tap gongahkia/aki
+$ brew install --cask aki
+```
+
+Equivalent one-line install:
+
+```console
+$ brew install --cask gongahkia/aki/aki
+```
+
+## Upgrade
+
+```console
+$ brew update
+$ brew upgrade --cask aki
+```
+
+## Uninstall
+
+```console
+$ brew uninstall --cask aki
+$ brew untap gongahkia/aki
+```
+
+## Release Coupling
+
+The cask points at:
+
+```text
+https://github.com/gongahkia/aki/releases/download/v#{version}/Aki-#{version}-macos.dmg
+```
+
+The DMG must be signed and notarized by the macOS release workflow before the cask is advertised as a working install path for that version.
+
+The cask currently uses `sha256 :no_check` because the release workflow creates the DMG and checksum at release time. The DMG still goes through Developer ID signing, notarization, stapling, and Gatekeeper validation in `scripts/release_macos_dmg.sh`.
+
+## Validation
+
+Local syntax and style checks:
+
+```console
+$ brew style --cask gongahkia/aki/aki
+$ brew audit --cask --skip-style gongahkia/aki/aki
+$ brew info --cask gongahkia/aki/aki
+```
+
+End-to-end install validation requires the signed/notarized GitHub Release artifact to exist:
+
+```console
+$ brew tap gongahkia/aki
+$ brew install --cask aki
+$ brew uninstall --cask aki
+```

--- a/docs/macos-release.md
+++ b/docs/macos-release.md
@@ -83,6 +83,8 @@ The workflow creates or updates the requested GitHub Release and uploads the DMG
 
 Contributors without release credentials should use `scripts/release_macos_dmg.sh --unsigned` instead of the signed workflow.
 
+After the signed DMG is published, validate the Homebrew cask path documented in [`docs/homebrew-cask.md`](./homebrew-cask.md).
+
 ## Failure Modes
 
 If `AKI_SIGN_IDENTITY` is missing or is not a Developer ID Application identity, the script fails before creating a public release artifact.


### PR DESCRIPTION
## Summary
- adds Casks/aki.rb for the gongahkia/aki tap
- documents the tap decision, install/upgrade/uninstall commands, release coupling, and validation commands
- updates README to make the Homebrew cask the primary macOS release install path with source install as fallback until a signed DMG is published
- links cask validation from the macOS release docs

Closes #9

## Validation
- temporarily exposed this checkout as local tap gongahkia/aki for Homebrew token-based validation
- brew style --cask gongahkia/aki/aki
- brew audit --cask --skip-style gongahkia/aki/aki
- brew info --cask gongahkia/aki/aki
- git diff --check

## Note
End-to-end brew install depends on the signed/notarized GitHub Release DMG existing at the cask URL. The cask points at that release URL; the release workflow from #7 is responsible for producing and publishing the artifact.