### PR TITLE
Document external rule pack import

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Named profiles (e.g. `[profiles.streaming]`) can override transform mode and int
 
 ### Optional external detector rules
 
-`Aki` can import gitleaks-style TOML rules from a local file. This is opt-in and local-only; `Aki` does not fetch rule packs or depend on a cloud scanner.
+`Aki` can import gitleaks-style TOML rules from a local file. This is opt-in and local-only; `Aki` does not fetch rule packs or depend on a cloud scanner. Details are documented in [`docs/external-rule-packs.md`](./docs/external-rule-packs.md).
 
 ```toml
 [detection]

--- a/docs/external-rule-packs.md
+++ b/docs/external-rule-packs.md
@@ -43,7 +43,7 @@ If the configured rule file cannot be parsed or a rule regex cannot compile with
 Use `aki test-patterns` with a temporary config to verify imported rules:
 
 ```console
-$ XDG_CONFIG_HOME=/tmp/aki-config aki test-patterns "token=ghp_abcdefghijklmnopqrstuvwxyzABCDEFGH12"
+$ XDG_CONFIG_HOME=/tmp/aki-config aki test-patterns "token=example-redacted-value"
 ```
 
 The test fixture in `privacy-core/fixtures/gitleaks_rules.toml` covers gitleaks import behavior in `cargo test --all`.

--- a/docs/external-rule-packs.md
+++ b/docs/external-rule-packs.md
@@ -1,0 +1,49 @@
+# External Rule Packs
+
+`Aki` can optionally import established secret-detection regex rules from a local gitleaks TOML file.
+
+## Decision
+
+V1 supports gitleaks-style TOML rules. Gitleaks rules expose `id` and `regex` fields that map directly into Aki's existing regex-based detector registry.
+
+Trufflehog is not imported in v1. Its detectors are more code- and entropy-oriented, so a faithful import would require a larger detector abstraction than the current regex registry. Treat trufflehog as an evaluated but deferred format.
+
+## Config
+
+```toml
+[detection]
+external_rules_path = "/path/to/gitleaks.toml"
+external_rules_format = "gitleaks"
+max_external_patterns = 128
+```
+
+The rule pack is local-only. Aki does not download rule packs or call a cloud scanner.
+
+## Imported Fields
+
+For each `[[rules]]` entry, Aki reads:
+
+- `id`
+- `regex`
+
+Other gitleaks fields, such as `description`, `keywords`, `tags`, and `entropy`, are accepted by the TOML parser but are not interpreted by v1.
+
+Imported pattern names are prefixed with `gitleaks:`. For example, a gitleaks rule with `id = "github-pat"` becomes `gitleaks:github-pat` in Aki's pattern manager and detection logs.
+
+## Bounds
+
+External rules are disabled unless `external_rules_path` is set.
+
+Imported rules are compiled once at startup. Runtime scan cost is bounded by `max_external_patterns`, and Aki hard-caps that value at 128 imported patterns. Individual imported regex strings longer than 4096 bytes are skipped.
+
+If the configured rule file cannot be parsed or a rule regex cannot compile with Rust's regex engine, Aki logs a warning and continues with built-in/user rules.
+
+## Validation
+
+Use `aki test-patterns` with a temporary config to verify imported rules:
+
+```console
+$ XDG_CONFIG_HOME=/tmp/aki-config aki test-patterns "token=ghp_abcdefghijklmnopqrstuvwxyzABCDEFGH12"
+```
+
+The test fixture in `privacy-core/fixtures/gitleaks_rules.toml` covers gitleaks import behavior in `cargo test --all`.

--- a/privacy-core/fixtures/gitleaks_rules.toml
+++ b/privacy-core/fixtures/gitleaks_rules.toml
@@ -1,10 +1,10 @@
 title = "aki gitleaks fixture"
 
 [[rules]]
-id = "fixture-github-pat"
-description = "Fixture GitHub personal access token"
-regex = '''ghp_[A-Za-z0-9]{36}'''
-keywords = ["ghp_"]
+id = "fixture-aki-token"
+description = "Fixture Aki-only token shape"
+regex = '''aki_fixture_[A-Za-z0-9]{12}'''
+keywords = ["aki_fixture_"]
 
 [[rules]]
 id = "fixture-private-key"

--- a/privacy-core/src/detection/external_rules.rs
+++ b/privacy-core/src/detection/external_rules.rs
@@ -100,11 +100,11 @@ mod tests {
         let fixture = include_str!("../../fixtures/gitleaks_rules.toml");
         let patterns = load_gitleaks_from_str(fixture, DEFAULT_MAX_IMPORTED_PATTERNS).unwrap();
 
-        let github = patterns
+        let fixture_token = patterns
             .iter()
-            .find(|p| p.name == "gitleaks:fixture-github-pat")
+            .find(|p| p.name == "gitleaks:fixture-aki-token")
             .unwrap();
-        assert!(github.is_match("token=ghp_abcdefghijklmnopqrstuvwxyzABCDEFGH12"));
+        assert!(fixture_token.is_match("token=aki_fixture_ABCDEF123456"));
 
         let private_key = patterns
             .iter()


### PR DESCRIPTION
## Summary
- adds dedicated docs for the optional gitleaks rule-pack import
- documents why gitleaks is supported and trufflehog is deferred for v1
- documents imported fields, local-only behavior, performance bounds, and validation
- links the new doc from the README external detector section
- replaces the gitleaks fixture with an Aki-specific fake token shape so secret scanners do not flag test data

Closes #12

## Validation
- git diff --check
- cargo test -p privacy-core detection::external_rules -- --nocapture
- main branch already contains the implementation commit a00c4b7, whose push CI passed: cargo fmt, clippy, build, and tests
- implementation validation included cargo clippy --all-targets -- -D warnings, cargo test --all, and an XDG_CONFIG_HOME CLI smoke test matching the imported fixture rule