### PR TITLE
Document local redaction log decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Network activity is limited to actions you request: Homebrew or GitHub release d
 
 Future counters or diagnostics are out of scope for v1 unless they are explicit opt-in before any data leaves the machine.
 
+The TUI includes a local in-memory redaction log, with explicit export only. Its retention and privacy tradeoffs are documented in [`docs/redaction-log.md`](./docs/redaction-log.md).
+
 ## Install
 
 The primary macOS release install path is the Homebrew cask:

--- a/docs/redaction-log.md
+++ b/docs/redaction-log.md
@@ -1,0 +1,33 @@
+# Local Redaction Log
+
+## Decision
+
+V1 includes a local-only redaction event log in the TUI, but it is in-memory by default.
+
+The value is practical debugging and trust-building: users can confirm what Aki detected, when it was detected, and which rule fired. The privacy risk is that even redacted snippets and pattern metadata can reveal sensitive context, so Aki does not persist per-event logs automatically.
+
+## Default Behavior
+
+- UI exposure: the TUI detection panel shows recent detections.
+- Retention: the app keeps the most recent 50 detection entries in memory for the current session.
+- Stored fields: timestamp, pattern name, severity, redacted snippet, and bounds.
+- Persistence: none by default. Closing Aki drops the in-memory entries.
+- Uploads: none. The log is never sent to a server by Aki.
+
+Headless mode only exposes aggregate counters through the local control server stats and writes periodic aggregate session stats. It does not persist per-redaction event entries.
+
+## Explicit Export
+
+Press `e` in the TUI to export the current in-memory session log.
+
+Export path:
+
+```text
+~/.config/ascii-privacy/sessions/aki_session_<timestamp>.json
+```
+
+Exports are local files and may contain sensitive metadata. Treat them like debug artifacts: keep them only when needed, do not share them casually, and delete them when the investigation is done.
+
+## Deferred
+
+Automatic retention policies, encrypted log storage, and opt-in diagnostics upload are not part of v1.


### PR DESCRIPTION
## Summary
- documents the v1 decision to keep redaction events local-only and in-memory by default
- states retention, stored fields, explicit export path, and UI exposure
- calls out privacy risk and that exports are local debug artifacts
- links the decision from the README zero-telemetry section

Closes #13

## Validation
- git diff --check