### PR TITLE
[codex] add Show HN readiness gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $ AKI_BINARY="$PWD/target/debug/aki" swift run --package-path macos/AkiMenuBar
 
 The menu-bar shell can start and stop the headless redaction pipeline, pause or resume it, switch transforms, choose the capture/output mode used on restart, show redaction/FPS/CPU stats, and open the TUI in Terminal. The v1 sidecar protocol is documented in [`docs/sidecar-protocol.md`](./docs/sidecar-protocol.md).
 
-macOS DMG release packaging is documented in [`docs/macos-release.md`](./docs/macos-release.md), and the cask path is documented in [`docs/homebrew-cask.md`](./docs/homebrew-cask.md).
+macOS DMG release packaging is documented in [`docs/macos-release.md`](./docs/macos-release.md), and the cask path is documented in [`docs/homebrew-cask.md`](./docs/homebrew-cask.md). The Show HN launch gate is tracked in [`docs/show-hn-readiness.md`](./docs/show-hn-readiness.md); do not advertise a Show HN launch until that checklist is complete.
 
 ## Quick Commands
 

--- a/docs/show-hn-readiness.md
+++ b/docs/show-hn-readiness.md
@@ -1,0 +1,81 @@
+# Show HN Readiness Gate
+
+Do not submit a Show HN post until every required gate below is checked, dated, and backed by evidence. This checklist is a release gate, not a status report. Unchecked items mean the Show HN launch is not ready.
+
+## Required Gates
+
+| Gate | Pass condition | Evidence to record |
+|------|----------------|--------------------|
+| Signed DMG launches on a stock Mac | A signed and notarized `Aki-<version>-macos.dmg` downloads from the GitHub Release, mounts, installs, and launches on a Mac without local developer state. | Version, release URL, macOS version, architecture, `spctl` result, tester/date. |
+| Homebrew cask install works end to end | `brew tap gongahkia/aki && brew install --cask aki` installs the same signed DMG, launches `Aki.app`, and uninstalls cleanly. | Commands run, cask version, macOS version, architecture, tester/date. |
+| Hero GIF is in the README | `README.md` embeds `asset/demo/hero-ascii-redaction.gif`, and the file exists in the repository. | Commit SHA containing both README link and GIF file. |
+| External user has installed successfully | At least one person outside the maintainer's machine installs through the public path and confirms launch. | Tester name or handle, install path, macOS version, architecture, date, notes. |
+| Known limitations are published | `README.md` includes a `Known limitations` section that explains leak-risk boundaries and operational fallback. | Commit SHA or README permalink. |
+| Version numbers are consistent | Workspace version, README badge, cask version, release tag, and DMG filename all refer to the same version. | Version string, release tag, command output or permalinks. |
+
+## Tracking Checklist
+
+Write the evidence link, tester, and date next to each item before checking it off.
+
+- [ ] Signed DMG downloads, installs, and launches on a stock Mac:
+- [ ] Homebrew cask installs, launches, and uninstalls end to end:
+- [ ] README hero GIF is present and visible:
+- [ ] External user install is confirmed:
+- [ ] Known limitations section is published:
+- [ ] Cargo, README badge, cask, release tag, and DMG versions match:
+
+## Verification Commands
+
+Run these before marking the gate complete:
+
+```console
+$ rg -n "Version [0-9]|version-[0-9]|version \"|version = \"" README.md Cargo.toml Casks/aki.rb
+$ test -f asset/demo/hero-ascii-redaction.gif
+$ gh release view v0.1.0 --json tagName,name,assets
+$ xcrun stapler validate /Volumes/Aki/Aki.app
+$ spctl --assess --type open --verbose /Volumes/Aki/Aki.app
+$ brew tap gongahkia/aki
+$ brew install --cask aki
+$ brew uninstall --cask aki
+```
+
+Replace `v0.1.0` with the release being launched. Run the install checks on a machine that did not build the app locally.
+
+## Launch Copy Rule
+
+Draft launch copy may describe the intended product and current local-first behavior, but it must not claim the Show HN gate has passed until every required gate above is complete. Avoid wording like "ready for public launch" or "install now with Homebrew" while the signed DMG, cask install, and external-user install evidence are still missing.
+
+## Evidence Template
+
+Copy this block into the release notes or launch tracker when the gate is complete:
+
+```text
+Show HN gate for v<version>
+
+- Signed DMG:
+  - Release URL:
+  - macOS:
+  - Architecture:
+  - Tester/date:
+  - spctl/stapler result:
+- Homebrew cask:
+  - Commands:
+  - Cask version:
+  - Tester/date:
+- Hero GIF:
+  - README permalink:
+  - GIF permalink:
+- External install:
+  - Tester:
+  - Install path:
+  - macOS/architecture:
+  - Result:
+- Known limitations:
+  - README permalink:
+- Version consistency:
+  - Workspace:
+  - Badge:
+  - Cask:
+  - Release tag:
+  - DMG:
+```


### PR DESCRIPTION
## What changed

- Added `docs/show-hn-readiness.md` as an explicit Show HN launch gate.
- Linked the gate from the README near the release and cask docs.
- Included concrete pass conditions, evidence fields, verification commands, and a launch-copy rule that avoids claiming readiness before the gate is complete.

## Validation

- `git diff --check`
- `test -f asset/demo/hero-ascii-redaction.gif`
- `rg -n "Show HN|Known limitations|hero-ascii-redaction|version = \"0\.1\.0\"|Version 0\.1\.0|version \"0\.1\.0\"" README.md docs/show-hn-readiness.md Cargo.toml Casks/aki.rb`

Closes #14