### PR TITLE
[codex] implement offline video redaction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             pkg-config clang libclang-dev \
             libtesseract-dev libleptonica-dev tesseract-ocr \
+            ffmpeg \
             libxcb1-dev \
             libpipewire-0.3-dev libspa-0.2-dev
       - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2599,6 +2599,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simplelog",
+ "tempfile",
  "tokio",
  "tungstenite",
 ]

--- a/README.md
+++ b/README.md
@@ -76,9 +76,23 @@ macOS DMG release packaging is documented in [`docs/macos-release.md`](./docs/ma
 ```console
 $ aki list-windows
 $ aki test-patterns "SECRET_KEY=abc123"
+$ aki redact ./recording.mov --output ./recording.redacted.mov
 $ aki check-output
 $ aki --headless --source screen
 ```
+
+### Offline Video Redaction
+
+Use `aki redact` to process an existing screen recording without real-time capture or a virtual camera:
+
+```console
+$ aki redact ./recording.mov
+$ aki redact ./recording.mov --output ./recording.redacted.mov --transform ascii --intensity 0.9
+```
+
+The command decodes the first video stream with `ffmpeg`, runs the same local OCR, pattern detection, and transform logic used by the live pipeline on each frame, then writes a redacted video through `ffmpeg`. Install `ffmpeg` and `ffprobe` before using it.
+
+When `--output` is omitted, `Aki` writes next to the input as `<name>.redacted.<ext>`. Existing output files are refused unless `--overwrite` is passed, and the input file is never used as the output path.
 
 ## Power-User / Developer Commands
 

--- a/privacy-output/src/recorder.rs
+++ b/privacy-output/src/recorder.rs
@@ -1,7 +1,7 @@
 //! Frame recorder: pipes RGBA frames to an ffmpeg subprocess → MP4 output.
 //! Start/stop via Recorder::start() / Recorder::stop().
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use privacy_common::frame::TransformedFrame;
 use std::{
     io::Write,
@@ -67,7 +67,10 @@ impl Recorder {
     /// Flush stdin, wait for ffmpeg to finish encoding.
     pub fn stop(mut self) -> Result<String> {
         drop(self.stdin); // close stdin → ffmpeg will flush and exit
-        self.proc.wait().context("waiting for ffmpeg to finish")?;
+        let status = self.proc.wait().context("waiting for ffmpeg to finish")?;
+        if !status.success() {
+            bail!("ffmpeg encoder exited with status {status}");
+        }
         Ok(self.path)
     }
 }

--- a/privacy-tui/Cargo.toml
+++ b/privacy-tui/Cargo.toml
@@ -24,3 +24,6 @@ simplelog = "0.12"
 ctrlc = "3"
 tungstenite = "0.26"
 crossbeam-channel = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3.26.0"

--- a/privacy-tui/src/main.rs
+++ b/privacy-tui/src/main.rs
@@ -2,6 +2,7 @@ mod app;
 mod control_server;
 mod event;
 mod logging;
+mod offline_redact;
 mod shutdown;
 mod tui;
 mod ui;
@@ -10,6 +11,7 @@ use anyhow::{bail, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 use event::{is_quit, next_event, Event};
 use privacy_common::transform::TransformMode;
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 const TICK_RATE: Duration = Duration::from_millis(100); // 10 Hz
@@ -104,6 +106,23 @@ enum Command {
     TestScreen,
     /// Run detection pipeline self-test against synthetic sensitive data.
     SelfTest,
+    /// Redact an existing local video file and write a new redacted output.
+    Redact {
+        /// Input video file to redact.
+        input: PathBuf,
+        /// Output video path. Defaults to <input-stem>.redacted.<ext>.
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+        /// Transform mode to apply to detected regions. Defaults to config.
+        #[arg(long, value_enum)]
+        transform: Option<CliTransform>,
+        /// Transform intensity in the range 0.0 to 1.0. Defaults to config.
+        #[arg(long)]
+        intensity: Option<f32>,
+        /// Allow replacing an existing output file. The input file is never overwritten.
+        #[arg(long)]
+        overwrite: bool,
+    },
 }
 
 fn main() -> Result<()> {
@@ -127,6 +146,13 @@ fn main() -> Result<()> {
         Command::CheckOutput => cmd_check_output(),
         Command::TestScreen => cmd_test_screen(),
         Command::SelfTest => cmd_self_test(),
+        Command::Redact {
+            input,
+            output,
+            transform,
+            intensity,
+            overwrite,
+        } => cmd_redact(input, output, transform, intensity, overwrite),
     }
 }
 
@@ -286,6 +312,39 @@ fn transform_mode_from_config(mode: &str) -> TransformMode {
 fn runtime_registry_from_disk() -> privacy_core::detection::patterns::PatternRegistry {
     let cfg = privacy_core::config::AppConfig::load().unwrap_or_default();
     privacy_core::detection::registry::runtime_registry(&cfg)
+}
+
+fn cmd_redact(
+    input: PathBuf,
+    output: Option<PathBuf>,
+    transform: Option<CliTransform>,
+    intensity: Option<f32>,
+    overwrite: bool,
+) -> Result<()> {
+    let cfg = privacy_core::config::AppConfig::load().unwrap_or_default();
+    let mode = transform
+        .map(TransformMode::from)
+        .unwrap_or_else(|| transform_mode_from_config(&cfg.transform.mode));
+    let intensity = intensity.unwrap_or(cfg.transform.intensity);
+    if !(0.0..=1.0).contains(&intensity) {
+        bail!("--intensity must be between 0.0 and 1.0");
+    }
+
+    let summary = offline_redact::redact_video(offline_redact::RedactOptions {
+        input,
+        output,
+        transform_mode: mode,
+        intensity,
+        overwrite,
+        config: cfg,
+    })?;
+
+    println!(
+        "redacted {} frame(s), {} detected region(s)",
+        summary.frames, summary.detected_regions
+    );
+    println!("output: {}", summary.output.display());
+    Ok(())
 }
 
 fn apply_headless_control(

--- a/privacy-tui/src/offline_redact.rs
+++ b/privacy-tui/src/offline_redact.rs
@@ -1,0 +1,469 @@
+use anyhow::{anyhow, bail, Context, Result};
+use privacy_common::{
+    detection::{DetectedRegions, TextRegion},
+    frame::{RawFrame, TransformedFrame},
+    transform::TransformMode,
+};
+use privacy_core::{
+    config::AppConfig,
+    detection::{
+        expand::expand_and_merge, line_expand::expand_to_end_of_line, ocr::OcrEngine,
+        registry::runtime_registry, scanner::scan, whitelist::Whitelist,
+    },
+    transform::registry::apply_transform,
+};
+use serde::Deserialize;
+use std::{
+    fs,
+    io::Read,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
+
+pub(crate) struct RedactOptions {
+    pub input: PathBuf,
+    pub output: Option<PathBuf>,
+    pub transform_mode: TransformMode,
+    pub intensity: f32,
+    pub overwrite: bool,
+    pub config: AppConfig,
+}
+
+pub(crate) struct RedactSummary {
+    pub output: PathBuf,
+    pub frames: u64,
+    pub detected_regions: u64,
+}
+
+#[derive(Debug, Clone)]
+struct VideoInfo {
+    width: u32,
+    height: u32,
+    fps: f64,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProbeOutput {
+    streams: Vec<ProbeStream>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProbeStream {
+    width: Option<u32>,
+    height: Option<u32>,
+    avg_frame_rate: Option<String>,
+    r_frame_rate: Option<String>,
+}
+
+pub(crate) fn redact_video(options: RedactOptions) -> Result<RedactSummary> {
+    if !options.input.exists() {
+        bail!("input video does not exist: {}", options.input.display());
+    }
+    if !options.input.is_file() {
+        bail!("input path is not a file: {}", options.input.display());
+    }
+
+    let output = options
+        .output
+        .unwrap_or_else(|| default_output_path(&options.input));
+    ensure_output_allowed(&options.input, &output, options.overwrite)?;
+
+    let info = probe_video(&options.input)?;
+    let mut decoder = spawn_decoder(&options.input)?;
+    let stdout = decoder
+        .stdout
+        .as_mut()
+        .context("ffmpeg decoder stdout unavailable")?;
+    let frame_size = frame_size(info.width, info.height)?;
+    let mut recorder = privacy_output::recorder::Recorder::start(
+        output.to_string_lossy().to_string(),
+        info.width,
+        info.height,
+        rounded_fps(info.fps),
+    )?;
+
+    let registry = runtime_registry(&options.config);
+    let whitelist = Whitelist::load().unwrap_or_else(|_| Whitelist::empty());
+    let min_conf = options.config.detection.min_confidence as f32;
+    let mut ocr = OcrEngine::new_with_confidence(None, min_conf)?;
+    let mut frames = 0u64;
+    let mut detected_regions = 0u64;
+
+    loop {
+        let mut pixels = vec![0u8; frame_size];
+        if !read_exact_frame(stdout, &mut pixels)? {
+            break;
+        }
+
+        let frame = RawFrame {
+            pixels,
+            width: info.width,
+            height: info.height,
+            timestamp: chrono::Utc::now(),
+        };
+        let (transformed, regions) = redact_frame_with_ocr(
+            &frame,
+            &mut ocr,
+            &registry,
+            &whitelist,
+            options.transform_mode,
+            options.intensity,
+        )?;
+        detected_regions += regions as u64;
+        recorder.write_frame(&transformed)?;
+        frames += 1;
+    }
+
+    let decoder_status = decoder.wait().context("waiting for ffmpeg decoder")?;
+    let saved = PathBuf::from(recorder.stop()?);
+    if !decoder_status.success() {
+        bail!("ffmpeg decoder exited with status {decoder_status}");
+    }
+    if frames == 0 {
+        let _ = fs::remove_file(&saved);
+        bail!("input video contained no decodable frames");
+    }
+
+    Ok(RedactSummary {
+        output: saved,
+        frames,
+        detected_regions,
+    })
+}
+
+fn default_output_path(input: &Path) -> PathBuf {
+    let parent = input.parent().unwrap_or_else(|| Path::new(""));
+    let stem = input
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("video");
+    let ext = input
+        .extension()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("mp4");
+    parent.join(format!("{stem}.redacted.{ext}"))
+}
+
+fn ensure_output_allowed(input: &Path, output: &Path, overwrite: bool) -> Result<()> {
+    if paths_refer_to_same_file(input, output) {
+        bail!(
+            "refusing to overwrite input video; choose a different --output path: {}",
+            output.display()
+        );
+    }
+    if output.exists() && !overwrite {
+        bail!(
+            "output already exists: {} (pass --overwrite to replace it)",
+            output.display()
+        );
+    }
+    if let Some(parent) = output.parent() {
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("creating output directory {}", parent.display()))?;
+        }
+    }
+    Ok(())
+}
+
+fn paths_refer_to_same_file(input: &Path, output: &Path) -> bool {
+    match (input.canonicalize(), output.canonicalize()) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => input == output,
+    }
+}
+
+fn probe_video(input: &Path) -> Result<VideoInfo> {
+    let output = Command::new("ffprobe")
+        .args([
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=width,height,avg_frame_rate,r_frame_rate",
+            "-of",
+            "json",
+        ])
+        .arg(input)
+        .output()
+        .context("running ffprobe - install ffmpeg/ffprobe to use `aki redact`")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("ffprobe failed for {}: {}", input.display(), stderr.trim());
+    }
+
+    let probe: ProbeOutput =
+        serde_json::from_slice(&output.stdout).context("parsing ffprobe JSON output")?;
+    let stream = probe
+        .streams
+        .first()
+        .ok_or_else(|| anyhow!("no video stream found in {}", input.display()))?;
+    let width = stream
+        .width
+        .filter(|w| *w > 0)
+        .ok_or_else(|| anyhow!("ffprobe did not report a valid width"))?;
+    let height = stream
+        .height
+        .filter(|h| *h > 0)
+        .ok_or_else(|| anyhow!("ffprobe did not report a valid height"))?;
+    let fps = stream
+        .avg_frame_rate
+        .as_deref()
+        .and_then(parse_fps)
+        .or_else(|| stream.r_frame_rate.as_deref().and_then(parse_fps))
+        .unwrap_or(30.0);
+
+    Ok(VideoInfo { width, height, fps })
+}
+
+fn parse_fps(raw: &str) -> Option<f64> {
+    if let Some((num, den)) = raw.split_once('/') {
+        let num = num.parse::<f64>().ok()?;
+        let den = den.parse::<f64>().ok()?;
+        if den <= 0.0 {
+            return None;
+        }
+        let fps = num / den;
+        return (fps > 0.0).then_some(fps);
+    }
+    let fps = raw.parse::<f64>().ok()?;
+    (fps > 0.0).then_some(fps)
+}
+
+fn rounded_fps(fps: f64) -> u32 {
+    fps.round().clamp(1.0, 240.0) as u32
+}
+
+fn spawn_decoder(input: &Path) -> Result<std::process::Child> {
+    Command::new("ffmpeg")
+        .args(["-hide_banner", "-loglevel", "error", "-i"])
+        .arg(input)
+        .args([
+            "-map", "0:v:0", "-f", "rawvideo", "-pix_fmt", "rgba", "pipe:1",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .context("running ffmpeg decoder - install ffmpeg/ffprobe to use `aki redact`")
+}
+
+fn frame_size(width: u32, height: u32) -> Result<usize> {
+    let pixels = width
+        .checked_mul(height)
+        .and_then(|p| p.checked_mul(4))
+        .ok_or_else(|| anyhow!("video dimensions are too large: {width}x{height}"))?;
+    Ok(pixels as usize)
+}
+
+fn read_exact_frame(reader: &mut impl Read, buf: &mut [u8]) -> Result<bool> {
+    let mut offset = 0usize;
+    while offset < buf.len() {
+        match reader
+            .read(&mut buf[offset..])
+            .context("reading decoded frame")?
+        {
+            0 if offset == 0 => return Ok(false),
+            0 => bail!("ffmpeg decoder ended with a partial frame"),
+            n => offset += n,
+        }
+    }
+    Ok(true)
+}
+
+fn redact_frame_with_ocr(
+    frame: &RawFrame,
+    ocr: &mut OcrEngine,
+    registry: &privacy_core::detection::patterns::PatternRegistry,
+    whitelist: &Whitelist,
+    mode: TransformMode,
+    intensity: f32,
+) -> Result<(TransformedFrame, usize)> {
+    let text_regions = ocr.extract(frame).unwrap_or_default();
+    redact_frame_with_regions(frame, &text_regions, registry, whitelist, mode, intensity)
+}
+
+fn redact_frame_with_regions(
+    frame: &RawFrame,
+    text_regions: &[TextRegion],
+    registry: &privacy_core::detection::patterns::PatternRegistry,
+    whitelist: &Whitelist,
+    mode: TransformMode,
+    intensity: f32,
+) -> Result<(TransformedFrame, usize)> {
+    let matches = scan(text_regions, registry, whitelist);
+    let merged = expand_and_merge(matches, frame.width, frame.height, 0.10);
+    let merged = expand_to_end_of_line(merged, frame.width);
+    let regions = DetectedRegions { matches: merged };
+    let count = regions.matches.len();
+    let transformed = apply_transform(frame, &regions, mode, intensity)?;
+    Ok((transformed, count))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use privacy_common::{detection::TextRegion, frame::Rect};
+    use privacy_core::detection::{default_patterns::default_registry, whitelist::Whitelist};
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    #[test]
+    fn default_output_inserts_redacted_before_extension() {
+        let path = Path::new("/tmp/demo.mov");
+        assert_eq!(
+            default_output_path(path),
+            PathBuf::from("/tmp/demo.redacted.mov")
+        );
+    }
+
+    #[test]
+    fn output_guard_rejects_input_path_and_existing_output_without_overwrite() {
+        let dir = tempdir().unwrap();
+        let input = dir.path().join("input.mov");
+        let output = dir.path().join("input.redacted.mov");
+        fs::write(&input, b"input").unwrap();
+        fs::write(&output, b"output").unwrap();
+
+        assert!(ensure_output_allowed(&input, &input, true).is_err());
+        assert!(ensure_output_allowed(&input, &output, false).is_err());
+        assert!(ensure_output_allowed(&input, &output, true).is_ok());
+    }
+
+    #[test]
+    fn fixture_video_frame_redacts_detected_secret_region() {
+        let frame = fixture_video_frame();
+        let regions = vec![TextRegion {
+            text: "SECRET_KEY=aki_fixture_value".to_string(),
+            bounds: Rect {
+                x: 8,
+                y: 8,
+                width: 48,
+                height: 24,
+            },
+            confidence: 99.0,
+        }];
+
+        let (redacted, count) = redact_frame_with_regions(
+            &frame,
+            &regions,
+            &default_registry(),
+            &Whitelist::empty(),
+            TransformMode::Pixelate,
+            1.0,
+        )
+        .unwrap();
+
+        assert_eq!(count, 1);
+        assert_ne!(redacted.pixels, frame.pixels);
+    }
+
+    #[test]
+    fn generated_video_file_is_processed_to_output() {
+        if !tool_available("ffmpeg") || !tool_available("ffprobe") {
+            eprintln!("skipping offline video test because ffmpeg/ffprobe is unavailable");
+            return;
+        }
+
+        let dir = tempdir().unwrap();
+        let input = dir.path().join("blank.mp4");
+        let output = dir.path().join("blank.redacted.mp4");
+        write_blank_video(&input).unwrap();
+
+        let summary = redact_video(RedactOptions {
+            input,
+            output: Some(output.clone()),
+            transform_mode: TransformMode::Pixelate,
+            intensity: 1.0,
+            overwrite: false,
+            config: AppConfig::default(),
+        })
+        .unwrap();
+
+        assert_eq!(summary.frames, 1);
+        assert_eq!(summary.detected_regions, 0);
+        assert_eq!(summary.output, output);
+        assert!(summary.output.exists());
+    }
+
+    fn fixture_video_frame() -> RawFrame {
+        let width = 80u32;
+        let height = 48u32;
+        let mut pixels = Vec::with_capacity((width * height * 4) as usize);
+        for y in 0..height {
+            for x in 0..width {
+                pixels.push(((x * 3) % 255) as u8);
+                pixels.push(((y * 5) % 255) as u8);
+                pixels.push((((x + y) * 2) % 255) as u8);
+                pixels.push(255);
+            }
+        }
+        RawFrame {
+            pixels,
+            width,
+            height,
+            timestamp: chrono::Utc::now(),
+        }
+    }
+
+    fn tool_available(name: &str) -> bool {
+        Command::new(name)
+            .arg("-version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    }
+
+    fn write_blank_video(path: &Path) -> Result<()> {
+        let width = 64u32;
+        let height = 48u32;
+        let mut child = Command::new("ffmpeg")
+            .args([
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-y",
+                "-f",
+                "rawvideo",
+                "-pixel_format",
+                "rgba",
+                "-video_size",
+                &format!("{width}x{height}"),
+                "-framerate",
+                "1",
+                "-i",
+                "pipe:0",
+                "-frames:v",
+                "1",
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+            ])
+            .arg(path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .context("spawning ffmpeg fixture writer")?;
+
+        let frame = vec![255u8; (width * height * 4) as usize];
+        child
+            .stdin
+            .as_mut()
+            .context("ffmpeg fixture stdin unavailable")?
+            .write_all(&frame)
+            .context("writing fixture frame")?;
+        drop(child.stdin.take());
+        let status = child.wait().context("waiting for ffmpeg fixture writer")?;
+        if !status.success() {
+            bail!("ffmpeg fixture writer exited with status {status}");
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## What changed

- Added `aki redact <video>` for offline video redaction with `--output`, `--transform`, `--intensity`, and `--overwrite` options.
- Decodes the first video stream through ffmpeg, runs local OCR plus the existing pattern scan and transform logic per frame, then writes the redacted result back through the existing recorder path.
- Refuses to overwrite the input path and requires `--overwrite` before replacing an existing output file.
- Documented input/output behavior in the README and made CI install ffmpeg for the video smoke test.
- Added tests for output path safety, a synthetic fixture frame with a detected fake secret, and generated-video processing.

## Validation

- `cargo fmt --all`
- `cargo test -p privacy-tui offline_redact -- --nocapture`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all`
- `git diff --check`

Closes #15