### PR TITLE
[codex] add fake secret demo command

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,22 @@ macOS DMG release packaging is documented in [`docs/macos-release.md`](./docs/ma
 ```console
 $ aki list-windows
 $ aki test-patterns "SECRET_KEY=abc123"
+$ aki demo --frames 1 --no-clear
 $ aki redact ./recording.mov --output ./recording.redacted.mov
 $ aki check-output
 $ aki --headless --source screen
 ```
+
+### Fake-Secret Demo
+
+Use `aki demo` when you need a safe screen-share source, screenshot, tweet, or issue reproduction without exposing real secrets:
+
+```console
+$ aki demo
+$ aki demo --frames 1 --no-clear
+```
+
+The demo prints deterministic rolling examples marked with `DEMO_`, `AKI_FAKE_`, and `DO_NOT_USE`, plus reserved documentation email and IP-shaped values. It is designed to be captured by the live pipeline and to be pasted into bug reports without containing real credentials.
 
 ### Offline Video Redaction
 

--- a/privacy-tui/src/demo.rs
+++ b/privacy-tui/src/demo.rs
@@ -1,0 +1,117 @@
+use anyhow::Result;
+use std::{
+    io::{self, Write},
+    thread,
+    time::Duration,
+};
+
+pub(crate) struct DemoOptions {
+    pub frames: u32,
+    pub interval_ms: u64,
+    pub no_clear: bool,
+}
+
+const FAKE_ROWS: &[&str] = &[
+    "DEMO_SECRET_KEY=AKI_FAKE_SECRET_DO_NOT_USE_0001",
+    "DEMO_API_TOKEN=AKI_FAKE_TOKEN_DO_NOT_USE_0002",
+    "DEMO_PASSWORD=AKI_FAKE_PASSWORD_DO_NOT_USE_0003",
+    "DEMO_EMAIL=demo-user@example.invalid",
+    "DEMO_IPV4=203.0.113.42",
+    "DEMO_IPV6=2001:db8::42",
+    "DEMO_JWT=AKI_FAKE_HEADER.AKI_FAKE_PAYLOAD.AKI_FAKE_SIGNATURE",
+    "DEMO_NOTE=all values on this screen are fake fixtures",
+];
+const VALUE_WIDTH: usize = 72;
+const BORDER: &str =
+    "+--------------------------------------------------------------------------+\n";
+
+pub(crate) fn run_demo(options: DemoOptions) -> Result<()> {
+    let mut stdout = io::stdout();
+    let mut frame = 0u32;
+    loop {
+        if !options.no_clear {
+            write!(stdout, "\x1b[2J\x1b[H")?;
+        }
+        write!(stdout, "{}", render_demo_frame(frame))?;
+        stdout.flush()?;
+
+        frame = frame.wrapping_add(1);
+        if options.frames > 0 && frame >= options.frames {
+            break;
+        }
+        if options.interval_ms > 0 {
+            thread::sleep(Duration::from_millis(options.interval_ms));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn render_demo_frame(frame: u32) -> String {
+    let offset = (frame as usize) % FAKE_ROWS.len();
+    let mut out = String::new();
+    out.push_str("AKI DEMO - FAKE SECRET REPRODUCTION SOURCE\n");
+    out.push_str("All values are deterministic fake fixtures. Do not paste real secrets here.\n\n");
+    out.push_str(&format!("frame={frame:04}  mode=rolling-fixtures\n"));
+    out.push_str(BORDER);
+    for row_idx in 0..FAKE_ROWS.len() {
+        let value = FAKE_ROWS[(offset + row_idx) % FAKE_ROWS.len()];
+        out.push_str(&format!("| {value:<width$} |\n", width = VALUE_WIDTH));
+    }
+    out.push_str(BORDER);
+    out.push('\n');
+    out.push_str(
+        "Use this terminal window as a safe screen-share, screenshot, or bug-report fixture.\n",
+    );
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use privacy_common::{detection::TextRegion, frame::Rect};
+    use privacy_core::{
+        config::AppConfig,
+        detection::{registry::runtime_registry, scanner::scan, whitelist::Whitelist},
+    };
+
+    #[test]
+    fn frame_rendering_is_deterministic() {
+        assert_eq!(render_demo_frame(3), render_demo_frame(3));
+    }
+
+    #[test]
+    fn frame_marks_values_as_fake() {
+        let frame = render_demo_frame(0);
+        assert!(frame.contains("AKI DEMO"));
+        assert!(frame.contains("FAKE"));
+        assert!(frame.contains("AKI_FAKE_SECRET_DO_NOT_USE"));
+        assert!(frame.contains("example.invalid"));
+        assert!(frame.contains("203.0.113.42"));
+    }
+
+    #[test]
+    fn rolling_frame_changes_row_order() {
+        assert_ne!(render_demo_frame(0), render_demo_frame(1));
+    }
+
+    #[test]
+    fn frame_text_matches_default_detector_registry() {
+        let text = render_demo_frame(0);
+        let regions = [TextRegion {
+            text,
+            bounds: Rect {
+                x: 0,
+                y: 0,
+                width: 800,
+                height: 300,
+            },
+            confidence: 99.0,
+        }];
+        let registry = runtime_registry(&AppConfig::default());
+        let matches = scan(&regions, &registry, &Whitelist::empty());
+
+        assert!(matches.iter().any(|m| m.pattern_name == "secret_keyword"));
+        assert!(matches.iter().any(|m| m.pattern_name == "email"));
+        assert!(matches.iter().any(|m| m.pattern_name == "ipv4"));
+    }
+}

--- a/privacy-tui/src/main.rs
+++ b/privacy-tui/src/main.rs
@@ -1,5 +1,6 @@
 mod app;
 mod control_server;
+mod demo;
 mod event;
 mod logging;
 mod offline_redact;
@@ -106,6 +107,18 @@ enum Command {
     TestScreen,
     /// Run detection pipeline self-test against synthetic sensitive data.
     SelfTest,
+    /// Print a rolling screen of deterministic fake secrets and PII-shaped fixtures.
+    Demo {
+        /// Number of frames to render. Use 0 to keep rolling until interrupted.
+        #[arg(long, default_value_t = 0)]
+        frames: u32,
+        /// Delay between rolling frames.
+        #[arg(long, default_value_t = 750)]
+        interval_ms: u64,
+        /// Do not clear the terminal before each frame.
+        #[arg(long)]
+        no_clear: bool,
+    },
     /// Redact an existing local video file and write a new redacted output.
     Redact {
         /// Input video file to redact.
@@ -146,6 +159,15 @@ fn main() -> Result<()> {
         Command::CheckOutput => cmd_check_output(),
         Command::TestScreen => cmd_test_screen(),
         Command::SelfTest => cmd_self_test(),
+        Command::Demo {
+            frames,
+            interval_ms,
+            no_clear,
+        } => demo::run_demo(demo::DemoOptions {
+            frames,
+            interval_ms,
+            no_clear,
+        }),
         Command::Redact {
             input,
             output,


### PR DESCRIPTION
## What changed

- Added `aki demo` as a rolling terminal reproduction source with deterministic fake values.
- Added `--frames`, `--interval-ms`, and `--no-clear` so it works both as a continuous screen-share source and as a one-frame bug-report fixture.
- Marked every sample as fake or documentation-reserved and avoided real credential-shaped values.
- Documented the command in the README.
- Added tests for deterministic rendering, rolling behavior, fake-value labeling, and detector-registry usefulness.

## Validation

- `cargo fmt --all`
- `cargo test -p privacy-tui demo -- --nocapture`
- `cargo run -p privacy-tui -- demo --frames 1 --no-clear`
- `cargo run -p privacy-tui -- demo --help`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all`
- `git diff --check`

Closes #16