### PR TITLE
[codex] add foreground detector profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,9 +305,18 @@ accelerator = "auto"        # auto | cuda | coreml | cpu (for neural mode)
 [output]
 sink = "auto"               # auto | v4l2 | coremedia | mjpeg
 http_port = 9876
+
+[foreground_profiles]
+enabled = true              # auto-select detector profile from foreground app
+override_profile = ""       # broad | secrets | pii | browser, or empty for auto
+update_interval_ms = 1000
 ```
 
-Named profiles (e.g. `[profiles.streaming]`) can override transform mode and intensity for different contexts.
+Automatic foreground detector profiles are macOS-first and use the frontmost app name when available. Terminals use the `secrets` detector profile, Slack/Discord/Messages use `pii`, VS Code/Cursor/Xcode use `broad`, and browsers use a broad OCR-based `browser` profile. Browser DOM inspection is not used in v1 because Aki stays pixel-first.
+
+Set `foreground_profiles.enabled = false` to disable automatic detector profile selection, or set `foreground_profiles.override_profile` to force one detector profile.
+
+Named transform profiles (e.g. `[profiles.streaming]`) can override transform mode and intensity for different contexts.
 
 ### Optional external detector rules
 

--- a/privacy-core/src/config.rs
+++ b/privacy-core/src/config.rs
@@ -180,6 +180,29 @@ impl Default for ProfileConfig {
     }
 }
 
+/// Automatic detector profile selection based on the foreground app.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ForegroundProfileConfig {
+    /// Enable automatic detector profile selection.
+    pub enabled: bool,
+    /// Force a detector profile by name: broad | secrets | pii | browser.
+    /// Empty or "auto" keeps foreground-app selection active.
+    pub override_profile: String,
+    /// Minimum interval between foreground app checks.
+    pub update_interval_ms: u64,
+}
+
+impl Default for ForegroundProfileConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            override_profile: String::new(),
+            update_interval_ms: 1000,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct AppConfig {
@@ -187,6 +210,7 @@ pub struct AppConfig {
     pub detection: DetectionConfig,
     pub transform: TransformConfig,
     pub output: OutputConfig,
+    pub foreground_profiles: ForegroundProfileConfig,
     /// Named profiles: [profiles.streaming], [profiles.pairing], etc.
     pub profiles: std::collections::HashMap<String, ProfileConfig>,
 }
@@ -235,5 +259,6 @@ mod tests {
         assert_eq!(back.detection.min_confidence, cfg.detection.min_confidence);
         assert!((back.transform.intensity - cfg.transform.intensity).abs() < 1e-6);
         assert_eq!(back.output.http_port, cfg.output.http_port);
+        assert!(back.foreground_profiles.enabled);
     }
 }

--- a/privacy-core/src/detection/mod.rs
+++ b/privacy-core/src/detection/mod.rs
@@ -15,6 +15,7 @@ pub mod line_expand;
 pub mod ocr;
 pub mod patterns;
 pub mod pii_patterns;
+pub mod profiles;
 pub mod registry;
 pub mod scanner;
 pub mod training;

--- a/privacy-core/src/detection/profiles.rs
+++ b/privacy-core/src/detection/profiles.rs
@@ -1,0 +1,203 @@
+//! Foreground-app detector profiles.
+//!
+//! Profiles intentionally control detector pattern enablement only. They do not
+//! change capture strategy or inspect browser DOM; the browser profile remains
+//! an OCR-based fallback so it fits Aki's pixel-first architecture.
+
+use privacy_common::detection::PatternCategory;
+
+use super::patterns::PatternRegistry;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DetectorProfileKind {
+    Broad,
+    Secrets,
+    Pii,
+    Browser,
+}
+
+impl DetectorProfileKind {
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Broad => "broad",
+            Self::Secrets => "secrets",
+            Self::Pii => "pii",
+            Self::Browser => "browser",
+        }
+    }
+
+    pub fn description(self) -> &'static str {
+        match self {
+            Self::Broad => "all default secret and PII detectors",
+            Self::Secrets => "secret-heavy rules for terminals and shells",
+            Self::Pii => "email and PII rules for chat surfaces",
+            Self::Browser => "broad OCR profile for browsers; no DOM inspection",
+        }
+    }
+}
+
+pub fn detector_profile_from_name(name: &str) -> Option<DetectorProfileKind> {
+    match name.trim().to_ascii_lowercase().as_str() {
+        "broad" | "editor" | "default" => Some(DetectorProfileKind::Broad),
+        "secrets" | "terminal" | "terminals" => Some(DetectorProfileKind::Secrets),
+        "pii" | "chat" | "slack" | "discord" => Some(DetectorProfileKind::Pii),
+        "browser" | "browsers" => Some(DetectorProfileKind::Browser),
+        "" | "auto" => None,
+        _ => None,
+    }
+}
+
+pub fn select_detector_profile(app_name: &str, window_title: &str) -> DetectorProfileKind {
+    let haystack = format!("{} {}", app_name, window_title).to_ascii_lowercase();
+
+    if contains_any(
+        &haystack,
+        &[
+            "terminal",
+            "iterm",
+            "ghostty",
+            "alacritty",
+            "warp",
+            "wezterm",
+            "kitty",
+            "tmux",
+            "zsh",
+            "bash",
+            "fish",
+        ],
+    ) {
+        return DetectorProfileKind::Secrets;
+    }
+
+    if contains_any(&haystack, &["slack", "discord", "messages", "teams"]) {
+        return DetectorProfileKind::Pii;
+    }
+
+    if contains_any(
+        &haystack,
+        &[
+            "visual studio code",
+            "vscode",
+            "vs code",
+            "cursor",
+            "xcode",
+            "zed",
+        ],
+    ) {
+        return DetectorProfileKind::Broad;
+    }
+
+    if contains_any(
+        &haystack,
+        &[
+            "safari", "chrome", "firefox", "arc", "brave", "edge", "browser",
+        ],
+    ) {
+        return DetectorProfileKind::Browser;
+    }
+
+    DetectorProfileKind::Broad
+}
+
+pub fn apply_detector_profile(registry: &mut PatternRegistry, profile: DetectorProfileKind) {
+    for pattern in &mut registry.patterns {
+        pattern.enabled = match profile {
+            DetectorProfileKind::Broad => true,
+            DetectorProfileKind::Secrets => matches!(
+                pattern.category,
+                PatternCategory::EnvVar
+                    | PatternCategory::Token
+                    | PatternCategory::Password
+                    | PatternCategory::ApiKey
+            ),
+            DetectorProfileKind::Pii => matches!(pattern.category, PatternCategory::Pii),
+            DetectorProfileKind::Browser => true,
+        };
+    }
+}
+
+fn contains_any(haystack: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| haystack.contains(needle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::detection::{registry::runtime_registry, scanner::scan, whitelist::Whitelist};
+    use privacy_common::{detection::TextRegion, frame::Rect};
+
+    #[test]
+    fn classifies_terminals_as_secrets() {
+        assert_eq!(
+            select_detector_profile("Ghostty", "zsh - project"),
+            DetectorProfileKind::Secrets
+        );
+    }
+
+    #[test]
+    fn classifies_chat_as_pii() {
+        assert_eq!(
+            select_detector_profile("Slack", "general"),
+            DetectorProfileKind::Pii
+        );
+        assert_eq!(
+            select_detector_profile("Discord", "support"),
+            DetectorProfileKind::Pii
+        );
+    }
+
+    #[test]
+    fn classifies_editors_and_browsers() {
+        assert_eq!(
+            select_detector_profile("Cursor", "main.rs"),
+            DetectorProfileKind::Broad
+        );
+        assert_eq!(
+            select_detector_profile("Safari", "Aki docs"),
+            DetectorProfileKind::Browser
+        );
+    }
+
+    #[test]
+    fn pii_profile_disables_secret_patterns() {
+        let mut registry = runtime_registry(&crate::config::AppConfig::default());
+        apply_detector_profile(&mut registry, DetectorProfileKind::Pii);
+
+        let regions = [text_region(
+            "user@example.invalid SECRET_KEY=aki_fixture_value",
+        )];
+        let matches = scan(&regions, &registry, &Whitelist::empty());
+
+        assert!(matches.iter().any(|m| m.pattern_name == "email"));
+        assert!(!matches.iter().any(|m| m.pattern_name == "secret_keyword"));
+    }
+
+    #[test]
+    fn secrets_profile_disables_pii_patterns() {
+        let mut registry = runtime_registry(&crate::config::AppConfig::default());
+        apply_detector_profile(&mut registry, DetectorProfileKind::Secrets);
+
+        let regions = [text_region(
+            "user@example.invalid SECRET_KEY=aki_fixture_value",
+        )];
+        let matches = scan(&regions, &registry, &Whitelist::empty());
+
+        assert!(matches
+            .iter()
+            .any(|m| m.pattern_name == "env_var_assignment"));
+        assert!(!matches.iter().any(|m| m.pattern_name == "email"));
+    }
+
+    fn text_region(text: &str) -> TextRegion {
+        TextRegion {
+            text: text.to_string(),
+            bounds: Rect {
+                x: 0,
+                y: 0,
+                width: 400,
+                height: 40,
+            },
+            confidence: 99.0,
+        }
+    }
+}

--- a/privacy-tui/src/app.rs
+++ b/privacy-tui/src/app.rs
@@ -1,10 +1,17 @@
 //! Application state shared across all TUI components.
 
-use crate::control_server::ControlState;
+use crate::{control_server::ControlState, foreground};
 use privacy_common::{frame::Rect, transform::TransformMode};
 use privacy_core::{
     config::AppConfig,
-    detection::{patterns::PatternRegistry, registry::runtime_registry},
+    detection::{
+        patterns::PatternRegistry,
+        profiles::{
+            apply_detector_profile, detector_profile_from_name, select_detector_profile,
+            DetectorProfileKind,
+        },
+        registry::runtime_registry,
+    },
 };
 use std::{
     collections::{HashMap, VecDeque},
@@ -193,6 +200,8 @@ pub struct App {
     pub preview_height: u32,
     /// Currently selected capture window id (None = full screen).
     pub selected_window_id: Option<u64>,
+    /// Title for the selected capture window, used as a fallback when foreground app detection is unavailable.
+    pub selected_window_title: Option<String>,
     pub window_selector: crate::ui::window_selector::WindowSelectorState,
     pub pattern_manager: crate::ui::pattern_manager::PatternManagerState,
     pub pattern_registry: PatternRegistry,
@@ -208,6 +217,22 @@ pub struct App {
     pub active_profile: Option<String>,
     /// Available profile names (loaded from config)
     pub profile_names: Vec<String>,
+    /// Active detector profile selected from foreground app, override, or disabled state.
+    pub detector_profile: DetectorProfileKind,
+    /// Source for active detector profile: auto, override, or disabled.
+    pub detector_profile_source: String,
+    /// Foreground app name observed during the most recent auto-profile check.
+    pub detector_profile_app: String,
+    /// Foreground window title observed during the most recent auto-profile check.
+    pub detector_profile_window: String,
+    /// Automatic detector profile selection enabled by config.
+    pub auto_detector_profiles_enabled: bool,
+    /// Optional config override for detector profile selection.
+    pub detector_profile_override: Option<DetectorProfileKind>,
+    /// Minimum interval between foreground app checks.
+    pub foreground_profile_interval: Duration,
+    /// Last foreground app profile check.
+    pub last_foreground_profile_check: Instant,
     /// Shared state with the WebSocket control server.
     pub control_state: Arc<ControlState>,
     /// Receives preview frame updates from the pipeline background thread.
@@ -251,6 +276,16 @@ impl App {
         };
         let transform_intensity = cfg.transform.intensity.clamp(0.0, 1.0);
         let profile_names: Vec<String> = cfg.profiles.keys().cloned().collect();
+        let mut pattern_registry = runtime_registry(&cfg);
+        let detector_profile_override =
+            detector_profile_from_name(&cfg.foreground_profiles.override_profile);
+        let detector_profile = detector_profile_override.unwrap_or(DetectorProfileKind::Broad);
+        apply_detector_profile(&mut pattern_registry, detector_profile);
+        let foreground_profile_interval = Duration::from_millis(
+            cfg.foreground_profiles
+                .update_interval_ms
+                .clamp(250, 10_000),
+        );
         Self {
             running: true,
             pipeline_state: PipelineState::Running,
@@ -266,9 +301,10 @@ impl App {
             preview_width: 0,
             preview_height: 0,
             selected_window_id: None,
+            selected_window_title: None,
             window_selector: crate::ui::window_selector::WindowSelectorState::new(),
             pattern_manager: crate::ui::pattern_manager::PatternManagerState::new(),
-            pattern_registry: runtime_registry(&cfg),
+            pattern_registry,
             heatmap: HeatmapState::new(),
             stats_overlay: StatsOverlayState::new(),
             latency_history: VecDeque::with_capacity(LATENCY_HISTORY_LEN),
@@ -276,6 +312,20 @@ impl App {
             recording_started_at: None,
             active_profile: None,
             profile_names,
+            detector_profile,
+            detector_profile_source: if detector_profile_override.is_some() {
+                "override".to_string()
+            } else if cfg.foreground_profiles.enabled {
+                "auto".to_string()
+            } else {
+                "disabled".to_string()
+            },
+            detector_profile_app: String::new(),
+            detector_profile_window: String::new(),
+            auto_detector_profiles_enabled: cfg.foreground_profiles.enabled,
+            detector_profile_override,
+            foreground_profile_interval,
+            last_foreground_profile_check: Instant::now(),
             control_state: ControlState::new(transform_mode, transform_intensity),
             preview_rx: None,
             pipeline_restart_needed: false,
@@ -346,6 +396,79 @@ impl App {
             );
             *ps.registry.lock().unwrap() = self.pattern_registry.clone();
         }
+    }
+
+    pub fn detector_profile_label(&self) -> &'static str {
+        self.detector_profile.name()
+    }
+
+    pub fn refresh_foreground_profile(&mut self) {
+        let selected_title = self.selected_window_title.as_deref();
+        let (profile, source, context) = if !self.auto_detector_profiles_enabled {
+            (
+                DetectorProfileKind::Broad,
+                "disabled",
+                foreground::ForegroundContext::fallback(selected_title),
+            )
+        } else if let Some(profile) = self.detector_profile_override {
+            (
+                profile,
+                "override",
+                foreground::ForegroundContext::fallback(selected_title),
+            )
+        } else if self.use_pty {
+            let context = foreground::ForegroundContext::terminal_pty();
+            (
+                select_detector_profile(&context.app_name, &context.window_title),
+                "auto",
+                context,
+            )
+        } else {
+            let context = foreground::detect(selected_title);
+            (
+                select_detector_profile(&context.app_name, &context.window_title),
+                "auto",
+                context,
+            )
+        };
+        self.apply_detector_profile_selection(profile, source, context);
+    }
+
+    pub fn tick_foreground_profile(&mut self) {
+        if self.last_foreground_profile_check.elapsed() < self.foreground_profile_interval {
+            return;
+        }
+        self.last_foreground_profile_check = Instant::now();
+        self.refresh_foreground_profile();
+    }
+
+    fn apply_detector_profile_selection(
+        &mut self,
+        profile: DetectorProfileKind,
+        source: &'static str,
+        context: foreground::ForegroundContext,
+    ) {
+        let unchanged = self.detector_profile == profile
+            && self.detector_profile_source == source
+            && self.detector_profile_app == context.app_name
+            && self.detector_profile_window == context.window_title;
+        if unchanged {
+            return;
+        }
+        log::info!(
+            "detector profile selected profile={} source={} app='{}' window='{}' description='{}'",
+            profile.name(),
+            source,
+            context.app_name,
+            context.window_title,
+            profile.description()
+        );
+        apply_detector_profile(&mut self.pattern_registry, profile);
+        self.detector_profile = profile;
+        self.detector_profile_source = source.to_string();
+        self.detector_profile_app = context.app_name;
+        self.detector_profile_window = context.window_title;
+        self.sync_pattern_registry_to_pipeline();
     }
 
     /// Advance crossfade counter by one tick; call once per Event::Tick.
@@ -437,6 +560,7 @@ impl App {
         if total_latency > 0.0 {
             self.record_latency(total_latency as u64);
         }
+        self.tick_foreground_profile();
         // apply pending pause/resume from control server
         if let Ok(mut g) = self.control_state.pending_pause.try_lock() {
             if let Some(paused) = g.take() {

--- a/privacy-tui/src/foreground.rs
+++ b/privacy-tui/src/foreground.rs
@@ -1,0 +1,106 @@
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ForegroundContext {
+    pub app_name: String,
+    pub window_title: String,
+}
+
+impl ForegroundContext {
+    pub(crate) fn terminal_pty() -> Self {
+        Self {
+            app_name: "Terminal".to_string(),
+            window_title: "pty".to_string(),
+        }
+    }
+
+    pub(crate) fn fallback(window_title: Option<&str>) -> Self {
+        Self {
+            app_name: String::new(),
+            window_title: window_title.unwrap_or_default().to_string(),
+        }
+    }
+}
+
+pub(crate) fn detect(selected_window_title: Option<&str>) -> ForegroundContext {
+    detect_platform().unwrap_or_else(|| ForegroundContext::fallback(selected_window_title))
+}
+
+#[cfg(target_os = "macos")]
+fn detect_platform() -> Option<ForegroundContext> {
+    use std::process::Command;
+
+    let output = Command::new("osascript")
+        .args([
+            "-e",
+            "tell application \"System Events\"",
+            "-e",
+            "set frontApp to first application process whose frontmost is true",
+            "-e",
+            "set appName to name of frontApp",
+            "-e",
+            "set windowName to \"\"",
+            "-e",
+            "try",
+            "-e",
+            "set windowName to name of front window of frontApp",
+            "-e",
+            "end try",
+            "-e",
+            "return appName & linefeed & windowName",
+            "-e",
+            "end tell",
+        ])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    parse_osascript_output(&String::from_utf8_lossy(&output.stdout))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn detect_platform() -> Option<ForegroundContext> {
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn parse_osascript_output(raw: &str) -> Option<ForegroundContext> {
+    let mut lines = raw.lines();
+    let app_name = lines.next().unwrap_or_default().trim().to_string();
+    let window_title = lines.next().unwrap_or_default().trim().to_string();
+    if app_name.is_empty() && window_title.is_empty() {
+        return None;
+    }
+    Some(ForegroundContext {
+        app_name,
+        window_title,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fallback_uses_selected_window_title() {
+        let ctx = ForegroundContext::fallback(Some("main.rs - Cursor"));
+        assert_eq!(ctx.app_name, "");
+        assert_eq!(ctx.window_title, "main.rs - Cursor");
+    }
+
+    #[test]
+    fn pty_context_classifies_as_terminal_like_text() {
+        let ctx = ForegroundContext::terminal_pty();
+        assert_eq!(ctx.app_name, "Terminal");
+        assert_eq!(ctx.window_title, "pty");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn parses_osascript_output() {
+        let ctx = parse_osascript_output("Safari\nAki docs\n").unwrap();
+        assert_eq!(ctx.app_name, "Safari");
+        assert_eq!(ctx.window_title, "Aki docs");
+    }
+}

--- a/privacy-tui/src/main.rs
+++ b/privacy-tui/src/main.rs
@@ -3,6 +3,7 @@ mod control_server;
 mod demo;
 mod doctor;
 mod event;
+mod foreground;
 mod logging;
 mod offline_redact;
 mod shutdown;
@@ -447,6 +448,7 @@ fn cmd_run(use_pty: bool) -> Result<()> {
     let mut app = app::App::new();
     app.use_pty = use_pty;
     auto_select_initial_window(&mut app);
+    app.refresh_foreground_profile();
     let sink_kind = detect_best_sink(9876);
     app.active_sink_kind = Some(sink_kind.clone());
     let sink = Arc::new(Mutex::new(create_sink(sink_kind)?));
@@ -519,6 +521,7 @@ fn auto_select_initial_window(app: &mut app::App) {
 
     if let Some(w) = pick {
         app.selected_window_id = Some(w.id);
+        app.selected_window_title = Some(w.title.clone());
         log::info!(
             "auto-select window: id={} title='{}' {}x{}",
             w.id,
@@ -828,10 +831,12 @@ fn handle_event(app: &mut app::App, ev: Event) {
                         app.window_selector.move_up()
                     }
                     KeyCode::Enter => {
-                        let id = app.window_selector.selected_window().map(|w| w.id);
-                        if let Some(id) = id {
-                            log::info!("action:window_selector.select window_id={id}");
-                            app.selected_window_id = Some(id);
+                        let selected = app.window_selector.selected_window().cloned();
+                        if let Some(window) = selected {
+                            log::info!("action:window_selector.select window_id={}", window.id);
+                            app.selected_window_id = Some(window.id);
+                            app.selected_window_title = Some(window.title);
+                            app.refresh_foreground_profile();
                             app.pipeline_restart_needed = true;
                         }
                         log::debug!("action:window_selector.close");

--- a/privacy-tui/src/ui/stats_bar.rs
+++ b/privacy-tui/src/ui/stats_bar.rs
@@ -40,7 +40,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         Span::raw("│ "),
         Span::styled(pipeline_icon, Style::default().fg(pipeline_color)),
         Span::raw(format!(
-            " {:.1}fps  │  cap:{:.0}ms ocr:{:.0}ms tx:{:.0}ms out:{:.0}ms tot:{:.0}ms  │  {:?} {:.0}%",
+            " {:.1}fps  │  cap:{:.0}ms ocr:{:.0}ms tx:{:.0}ms out:{:.0}ms tot:{:.0}ms  │  {:?} {:.0}%  │  profile:{}:{}",
             s.actual_fps,
             s.capture_latency_ms,
             s.ocr_latency_ms,
@@ -49,6 +49,8 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             total_lat,
             app.transform_mode,
             app.transform_intensity * 100.0,
+            app.detector_profile_label(),
+            app.detector_profile_source,
         )),
         {
             let neural_status = if app.transform_mode == TransformMode::Neural {


### PR DESCRIPTION
## What changed

- Added built-in detector profiles for broad, secrets-heavy, PII/chat, and browser OCR flows.
- Added foreground app classification that is macOS-first and falls back to selected window title when foreground app probing is unavailable.
- Applies detector profiles automatically at TUI startup and periodically while running, then syncs the filtered registry into the live pipeline.
- Added config controls to disable automatic foreground profile selection or force a profile override.
- Shows the active detector profile/source in the TUI status bar.
- Documented the profile map, override, disable controls, and browser non-DOM behavior in the README.
- Added tests for classifier behavior and profile pattern filtering.

## Validation

- `cargo fmt --all`
- `cargo test -p privacy-core detection::profiles -- --nocapture`
- `cargo test -p privacy-tui -- --nocapture`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all`
- `git diff --check`

Closes #18