### PR TITLE
[codex] document community rule pack format

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Named transform profiles (e.g. `[profiles.streaming]`) can override transform mo
 
 ### Optional external detector rules
 
-`Aki` can import gitleaks-style TOML rules from a local file. This is opt-in and local-only; `Aki` does not fetch rule packs or depend on a cloud scanner. Details are documented in [`docs/external-rule-packs.md`](./docs/external-rule-packs.md).
+`Aki` can import gitleaks-style TOML rules from a local file. This is opt-in and local-only; `Aki` does not fetch rule packs or depend on a cloud scanner. Details are documented in [`docs/external-rule-packs.md`](./docs/external-rule-packs.md), and community rule-pack contribution conventions are documented in [`docs/community-rule-packs.md`](./docs/community-rule-packs.md).
 
 ```toml
 [detection]

--- a/docs/community-rule-packs.md
+++ b/docs/community-rule-packs.md
@@ -1,0 +1,83 @@
+# Community Rule Packs
+
+The planned community rule-pack repository is `gongahkia/aki-rules`. Until that repository is split out, this repo keeps the format contract and a sample pack under [`rule-packs/`](../rule-packs/).
+
+## Format
+
+Aki consumes community rule packs as local gitleaks-compatible TOML files. V1 reads only `id` and `regex`; other fields are kept for contributor clarity and future compatibility.
+
+```toml
+title = "aki community rules"
+
+[[rules]]
+id = "vendor-demo-token"
+description = "What this fake or vendor-specific token shape detects"
+regex = '''vendor_demo_[a-z0-9_]{16,}'''
+keywords = ["vendor_demo_"]
+tags = ["vendor", "token"]
+```
+
+Required fields:
+
+- `id`: stable, lowercase, hyphen-separated rule identifier.
+- `regex`: Rust `regex` syntax. Keep it bounded and specific.
+
+Recommended fields:
+
+- `description`: one sentence explaining the detector.
+- `keywords`: literals that make the rule easy to review.
+- `tags`: product, category, or owner labels.
+
+## Required Fixture
+
+Every rule contribution must include one fixture string that matches the rule. Fixtures must be fake, reserved, or project-specific examples that cannot be mistaken for a live credential.
+
+For example:
+
+- Rule: [`rule-packs/aki-rules-sample.toml`](../rule-packs/aki-rules-sample.toml)
+- Fixture: [`rule-packs/fixtures/sample-aki-demo-service-key.txt`](../rule-packs/fixtures/sample-aki-demo-service-key.txt)
+
+Do not submit real secrets, live customer examples, production tokens, private keys, or copied incident artifacts.
+
+## Required Tests
+
+Each new rule must include:
+
+- One regex or detector rule in the TOML pack.
+- One matching fixture under `fixtures/`.
+- One test that imports the pack and proves the fixture matches.
+
+In this repository, the sample pack is covered by:
+
+```console
+$ cargo test -p privacy-core detection::external_rules::tests::imports_community_rule_pack_sample
+```
+
+## Versioning
+
+`gongahkia/aki-rules` should use SemVer tags once it exists:
+
+- Patch: rule wording, fixture cleanup, or false-positive tightening that should not break expected matches.
+- Minor: new rules or new fixture categories.
+- Major: format changes or broad regex behavior changes that can alter scan cost or match semantics.
+
+Aki does not auto-download rule packs. Users pin a local checkout, release archive, or vendored file path and update it intentionally.
+
+## Local Consumption
+
+Configure Aki with a local rule-pack path:
+
+```toml
+[detection]
+external_rules_path = "/path/to/aki-rules/aki-rules.toml"
+external_rules_format = "gitleaks"
+max_external_patterns = 128
+```
+
+Then verify the pack locally:
+
+```console
+$ aki test-patterns "$(cat /path/to/aki-rules/fixtures/example.txt)"
+```
+
+Imported patterns are prefixed with `gitleaks:` in the pattern manager and detection logs. The import remains local-only; Aki does not call a cloud scanner or upload fixtures.

--- a/docs/external-rule-packs.md
+++ b/docs/external-rule-packs.md
@@ -1,6 +1,6 @@
 # External Rule Packs
 
-`Aki` can optionally import established secret-detection regex rules from a local gitleaks TOML file.
+`Aki` can optionally import established secret-detection regex rules from a local gitleaks TOML file. Community rule-pack contribution and versioning conventions are documented in [`docs/community-rule-packs.md`](./community-rule-packs.md).
 
 ## Decision
 
@@ -46,4 +46,4 @@ Use `aki test-patterns` with a temporary config to verify imported rules:
 $ XDG_CONFIG_HOME=/tmp/aki-config aki test-patterns "token=example-redacted-value"
 ```
 
-The test fixture in `privacy-core/fixtures/gitleaks_rules.toml` covers gitleaks import behavior in `cargo test --all`.
+The test fixture in `privacy-core/fixtures/gitleaks_rules.toml` covers gitleaks import behavior in `cargo test --all`. The community sample pack in `rule-packs/aki-rules-sample.toml` proves the planned `gongahkia/aki-rules` format can be consumed locally.

--- a/privacy-core/src/detection/external_rules.rs
+++ b/privacy-core/src/detection/external_rules.rs
@@ -119,4 +119,18 @@ mod tests {
         let patterns = load_gitleaks_from_str(fixture, 1).unwrap();
         assert_eq!(patterns.len(), 1);
     }
+
+    #[test]
+    fn imports_community_rule_pack_sample() {
+        let pack = include_str!("../../../rule-packs/aki-rules-sample.toml");
+        let fixture = include_str!("../../../rule-packs/fixtures/sample-aki-demo-service-key.txt");
+        let patterns = load_gitleaks_from_str(pack, DEFAULT_MAX_IMPORTED_PATTERNS).unwrap();
+        let sample = patterns
+            .iter()
+            .find(|p| p.name == "gitleaks:aki-demo-service-key")
+            .unwrap();
+
+        assert!(sample.is_match(fixture.trim()));
+        assert!(!sample.is_match("aki_demo_service_key=not_a_fixture"));
+    }
 }

--- a/rule-packs/aki-rules-sample.toml
+++ b/rule-packs/aki-rules-sample.toml
@@ -1,0 +1,8 @@
+title = "aki community rule pack sample"
+
+[[rules]]
+id = "aki-demo-service-key"
+description = "Sample community rule for an Aki-only fake service key fixture"
+regex = '''aki_demo_service_key=aki_fixture_[a-z0-9_]{12,}'''
+keywords = ["aki_demo_service_key", "aki_fixture_"]
+tags = ["aki", "sample", "fixture"]

--- a/rule-packs/fixtures/sample-aki-demo-service-key.txt
+++ b/rule-packs/fixtures/sample-aki-demo-service-key.txt
@@ -1,0 +1,1 @@
+aki_demo_service_key=aki_fixture_customer_token_0001


### PR DESCRIPTION
## What changed

- Added `docs/community-rule-packs.md` for the planned `gongahkia/aki-rules` repository, rule format, required fixtures/tests, versioning, and local consumption.
- Added a sample gitleaks-compatible community rule pack under `rule-packs/` with a fake fixture.
- Added a unit test proving Aki imports the sample pack through the existing local external-rule loader.
- Linked the community rule-pack guidance from the README and external-rule-pack docs.

## Validation

- `cargo fmt --all`
- `cargo test -p privacy-core detection::external_rules::tests::imports_community_rule_pack_sample -- --nocapture`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all`
- `git diff --check`
- Local `aki test-patterns` smoke test with a temporary config pointing at `rule-packs/aki-rules-sample.toml`

Closes #19