### PR TITLE
[codex] add OBS source plugin design

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ Currently `Aki` supports the following 4 outputs.
 | HTTP MJPEG stream | All | Available *(default fallback)* |
 | OBS WebSocket v5 *(Browser Source → MJPEG)* | All | Available *(falls back to MJPEG if OBS unreachable)* |
 
+The native OBS source/filter plugin design is documented in [`docs/obs-source-plugin.md`](./docs/obs-source-plugin.md). The current implementation keeps the virtual-camera and MJPEG paths intact while the OBS plugin remains a tested prototype adapter plus packaging plan.
+
 ### Architecture
 
 ![](./asset/reference/architecture.png)

--- a/docs/obs-source-plugin.md
+++ b/docs/obs-source-plugin.md
@@ -1,0 +1,88 @@
+# OBS Source Plugin Design
+
+This is the v2 design for reaching streamers directly inside OBS while keeping the existing virtual-camera and MJPEG paths intact.
+
+## Goal
+
+Build a native OBS source or filter plugin that sends OBS video frames through Aki's detector and transform pipeline, then returns redacted frames to OBS as a normal source/filter output.
+
+The current production path remains:
+
+```text
+screen capture -> Aki pipeline -> virtual camera or MJPEG -> OBS
+```
+
+The plugin path would be:
+
+```text
+OBS source/filter frame -> Aki detector + transform -> OBS texture output
+```
+
+## Frame Flow
+
+1. OBS calls the plugin on its video/render path with a frame from a selected source, scene, or plugin-owned capture source.
+2. The plugin stages the frame into an RGBA CPU buffer. GPU texture interop can be added later, but the prototype keeps the boundary explicit.
+3. The RGBA buffer is converted into `privacy_core::obs_plugin::ObsSourceFrame`.
+4. Aki runs OCR/pattern detection on the frame and produces `DetectedRegions`.
+5. Existing transforms are applied through `privacy_core::obs_plugin::apply_transform_to_obs_frame`.
+6. The transformed RGBA buffer is uploaded back to an OBS texture and emitted by the source/filter.
+
+The prototype adapter is compiled and tested in [`privacy-core/src/obs_plugin.rs`](../privacy-core/src/obs_plugin.rs). It verifies that an OBS-style RGBA frame can apply an existing Aki transform without going through the virtual-camera path.
+
+## Source vs Filter
+
+The first native implementation should be an OBS filter, not only a source:
+
+- A filter can wrap any existing OBS source, including display capture, window capture, cameras, and browser sources.
+- A source can still be useful for an Aki-managed MJPEG/browser-source style setup.
+- Both can share the same Rust core adapter once the OBS C/C++ boundary is in place.
+
+## Threading
+
+OBS render callbacks must not block on OCR. The plugin should use the same backpressure principle as Aki's current pipeline:
+
+- Copy or map the newest frame into a bounded queue.
+- Run OCR and pattern matching on worker threads.
+- Apply the most recent known redaction regions to the render-thread frame.
+- Drop stale frames instead of queueing latency.
+
+This means live streams may still have a short detection race window. The plugin does not change that limitation; it just removes the virtual-camera setup step for OBS users.
+
+## Transform Prototype
+
+The current prototype covers transform application:
+
+```console
+$ cargo test -p privacy-core obs_plugin -- --nocapture
+```
+
+The test builds a fake OBS RGBA frame, marks a region, applies the existing Pixelate transform, and verifies the output frame changes while preserving dimensions.
+
+Next native-plugin prototype steps:
+
+1. Generate an OBS plugin skeleton with `obs-plugintemplate`.
+2. Add a Rust staticlib or C ABI wrapper around the Aki core adapter.
+3. Copy one OBS frame into RGBA CPU memory and call the adapter.
+4. Upload the transformed frame back to an OBS texture.
+5. Add UI controls for transform mode, intensity, and detector profile.
+
+## Packaging And Distribution
+
+OBS plugin distribution is separate from Aki's macOS DMG:
+
+- macOS: ship a signed and notarized `.plugin` bundle under `~/Library/Application Support/obs-studio/plugins/aki-obs-source/`.
+- Linux: ship a shared object and data files matching OBS plugin layout for Flatpak and native OBS installs.
+- Windows: defer until the main Aki app has Windows capture support.
+
+Distribution channels:
+
+- GitHub Releases for versioned plugin artifacts.
+- OBS Project forum/resource listing after a signed macOS build and repeatable install docs exist.
+- Homebrew cask can stay focused on the Aki app; plugin packaging should be a separate artifact until the OBS install path is stable.
+
+## Non-Goals For The First Plugin
+
+- Replacing the virtual camera path.
+- Browser DOM inspection.
+- Sending frames or OCR text to a cloud service.
+- Supporting every OBS platform before the macOS plugin path is stable.

--- a/privacy-core/src/lib.rs
+++ b/privacy-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod capture;
 pub mod config;
 pub mod detection;
+pub mod obs_plugin;
 pub mod pipeline;
 pub mod pipeline_runner;
 pub mod transform;

--- a/privacy-core/src/obs_plugin.rs
+++ b/privacy-core/src/obs_plugin.rs
@@ -1,0 +1,132 @@
+//! Prototype adapter for a future native OBS source/filter plugin.
+//!
+//! OBS plugins can stage frames as CPU RGBA buffers. This adapter keeps that
+//! boundary explicit and reuses Aki's existing transform registry. Detection
+//! stays outside this prototype; a native plugin would feed OCR/detection
+//! results into `DetectedRegions` before calling this adapter.
+
+use anyhow::{anyhow, Result};
+use privacy_common::{
+    detection::DetectedRegions,
+    frame::{RawFrame, TransformedFrame},
+    transform::TransformMode,
+};
+
+use crate::transform::registry::apply_transform;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObsSourceFrame {
+    pub pixels: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
+}
+
+impl ObsSourceFrame {
+    pub fn new(pixels: Vec<u8>, width: u32, height: u32) -> Result<Self> {
+        let expected_len = frame_len(width, height)?;
+        if pixels.len() != expected_len {
+            return Err(anyhow!(
+                "OBS frame buffer length {} does not match {}x{} RGBA length {}",
+                pixels.len(),
+                width,
+                height,
+                expected_len
+            ));
+        }
+        Ok(Self {
+            pixels,
+            width,
+            height,
+        })
+    }
+
+    fn as_raw_frame(&self) -> RawFrame {
+        RawFrame {
+            pixels: self.pixels.clone(),
+            width: self.width,
+            height: self.height,
+            timestamp: chrono::Utc::now(),
+        }
+    }
+}
+
+pub fn apply_transform_to_obs_frame(
+    frame: &ObsSourceFrame,
+    regions: &DetectedRegions,
+    mode: TransformMode,
+    intensity: f32,
+) -> Result<ObsSourceFrame> {
+    let raw = frame.as_raw_frame();
+    let transformed = apply_transform(&raw, regions, mode, intensity)?;
+    ObsSourceFrame::try_from(transformed)
+}
+
+impl TryFrom<TransformedFrame> for ObsSourceFrame {
+    type Error = anyhow::Error;
+
+    fn try_from(frame: TransformedFrame) -> Result<Self> {
+        Self::new(frame.pixels, frame.width, frame.height)
+    }
+}
+
+fn frame_len(width: u32, height: u32) -> Result<usize> {
+    width
+        .checked_mul(height)
+        .and_then(|pixels| pixels.checked_mul(4))
+        .map(|bytes| bytes as usize)
+        .ok_or_else(|| anyhow!("OBS frame dimensions are too large: {}x{}", width, height))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use privacy_common::{
+        detection::{DetectedRegions, SensitiveMatch, Severity},
+        frame::Rect,
+        transform::TransformMode,
+    };
+
+    #[test]
+    fn rejects_invalid_rgba_buffer_length() {
+        let err = ObsSourceFrame::new(vec![0; 3], 2, 2).unwrap_err();
+        assert!(err.to_string().contains("does not match"));
+    }
+
+    #[test]
+    fn prototype_applies_existing_pixelate_transform() {
+        let frame = ObsSourceFrame::new(gradient_rgba(32, 24), 32, 24).unwrap();
+        let regions = DetectedRegions {
+            matches: vec![SensitiveMatch {
+                bounds: Rect {
+                    x: 4,
+                    y: 4,
+                    width: 16,
+                    height: 12,
+                },
+                pattern_name: "obs-prototype-fixture".to_string(),
+                severity: Severity::High,
+                snippet: "AKI_***".to_string(),
+            }],
+        };
+
+        let transformed =
+            apply_transform_to_obs_frame(&frame, &regions, TransformMode::Pixelate, 1.0).unwrap();
+
+        assert_eq!(transformed.width, frame.width);
+        assert_eq!(transformed.height, frame.height);
+        assert_ne!(transformed.pixels, frame.pixels);
+    }
+
+    fn gradient_rgba(width: u32, height: u32) -> Vec<u8> {
+        let mut pixels = Vec::with_capacity((width * height * 4) as usize);
+        for y in 0..height {
+            for x in 0..width {
+                pixels.push(((x * 7) % 255) as u8);
+                pixels.push(((y * 11) % 255) as u8);
+                pixels.push((((x + y) * 5) % 255) as u8);
+                pixels.push(255);
+            }
+        }
+        pixels
+    }
+}


### PR DESCRIPTION
## What changed

- Added `docs/obs-source-plugin.md` describing how OBS frames enter and leave the Aki pipeline, source vs filter tradeoffs, threading/backpressure, and packaging/distribution requirements.
- Added a compiled `privacy_core::obs_plugin` prototype adapter for OBS-style RGBA source frames.
- The prototype applies existing Aki transforms to marked regions without changing the virtual-camera or MJPEG paths.
- Linked the OBS plugin design from the README output-support section.

## Validation

- `cargo fmt --all`
- `cargo test -p privacy-core obs_plugin -- --nocapture`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all`
- `git diff --check`

Closes #20