### PR TITLE
[codex] add time-machine redaction buffer prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ The command decodes the first video stream with `ffmpeg`, runs the same local OC
 
 When `--output` is omitted, `Aki` writes next to the input as `<name>.redacted.<ext>`. Existing output files are refused unless `--overwrite` is passed, and the input file is never used as the output path.
 
+The recording-only time-machine buffer prototype is documented in [`docs/time-machine-buffer.md`](./docs/time-machine-buffer.md). It can re-render buffered local-recording frames before finalization, but it cannot unsend live-stream or screen-share pixels.
+
 ## Power-User / Developer Commands
 
 ```console

--- a/docs/time-machine-buffer.md
+++ b/docs/time-machine-buffer.md
@@ -1,0 +1,70 @@
+# Time-Machine Redaction Buffer
+
+This is a prototype for retroactive redaction in local recordings. It is not a live-stream undo feature.
+
+## UX Boundary
+
+The time-machine buffer can help when the user is making a local recording and wants to fix a missed redaction before finalizing the recording file.
+
+It cannot unsend pixels that have already gone to:
+
+- a livestream,
+- a virtual camera,
+- an OBS/MJPEG client,
+- a screen-share call.
+
+The UI must present this as a recording workflow only. Copy should say "fix before saving recording", not "undo a leak".
+
+## Prototype
+
+The compiled prototype lives in [`privacy-core/src/time_machine.rs`](../privacy-core/src/time_machine.rs).
+
+It supports:
+
+- a bounded ring buffer of recent raw frames and their detected regions,
+- automatic dropping of the oldest frames when capacity is reached,
+- adding a manual missed region to recent buffered frames,
+- re-rendering buffered frames with an existing transform before a local recording is finalized,
+- raw RGBA memory estimation.
+
+Run:
+
+```console
+$ cargo test -p privacy-core time_machine -- --nocapture
+```
+
+## Memory Cost
+
+Raw RGBA buffering is expensive. A 30-second buffer at 30 FPS keeps 900 frames.
+
+| Resolution | Bytes per frame | 30s raw RGBA buffer |
+|------------|-----------------|---------------------|
+| 1280x720 | 3,686,400 | 3.09 GiB |
+| 1920x1080 | 8,294,400 | 6.95 GiB |
+| 3840x2160 | 33,177,600 | 27.80 GiB |
+
+This makes a full-resolution raw frame buffer too expensive as the default. Practical follow-ups should evaluate:
+
+- lower-resolution detection buffers,
+- compressed intra-frame snapshots,
+- shorter default retention,
+- disk-backed buffers with explicit opt-in,
+- storing detection metadata plus keyframes instead of every raw frame.
+
+## Disk Cost
+
+The prototype does not write the buffer to disk. If a future recording workflow uses disk-backed retention, the UI must show the configured location and retention size before enabling it.
+
+Disk-backed buffers should be treated as sensitive local artifacts because missed secrets may still be present in pre-redaction frames.
+
+## Recording Flow
+
+Prototype flow for local recording:
+
+1. Keep recent frames and detected regions in `TimeMachineBuffer`.
+2. If the user spots missed content before finalizing the recording, add a manual region over the affected recent frames.
+3. Re-render buffered frames with the selected transform.
+4. Write the corrected frames into the local recording output.
+5. Drop the raw buffer after finalization.
+
+Live output continues to use the normal real-time pipeline and does not wait for retroactive fixes.

--- a/privacy-core/src/lib.rs
+++ b/privacy-core/src/lib.rs
@@ -4,4 +4,5 @@ pub mod detection;
 pub mod obs_plugin;
 pub mod pipeline;
 pub mod pipeline_runner;
+pub mod time_machine;
 pub mod transform;

--- a/privacy-core/src/time_machine.rs
+++ b/privacy-core/src/time_machine.rs
@@ -1,0 +1,179 @@
+//! Prototype ring buffer for local-recording retroactive redaction.
+//!
+//! This is intentionally separate from live output. It can re-render buffered
+//! frames before a local recording is finalized, but it cannot unsend frames
+//! that already went to a livestream, virtual camera, or MJPEG client.
+
+use anyhow::{anyhow, Result};
+use privacy_common::{
+    detection::{DetectedRegions, SensitiveMatch},
+    frame::{RawFrame, TransformedFrame},
+    transform::TransformMode,
+};
+use std::collections::VecDeque;
+
+use crate::transform::registry::apply_transform;
+
+#[derive(Debug, Clone)]
+pub struct BufferedFrame {
+    pub frame: RawFrame,
+    pub regions: DetectedRegions,
+}
+
+#[derive(Debug)]
+pub struct TimeMachineBuffer {
+    capacity_frames: usize,
+    frames: VecDeque<BufferedFrame>,
+}
+
+impl TimeMachineBuffer {
+    pub fn new(seconds: u32, fps: u32) -> Self {
+        let capacity_frames = seconds.saturating_mul(fps).max(1) as usize;
+        Self {
+            capacity_frames,
+            frames: VecDeque::with_capacity(capacity_frames),
+        }
+    }
+
+    pub fn capacity_frames(&self) -> usize {
+        self.capacity_frames
+    }
+
+    pub fn len(&self) -> usize {
+        self.frames.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.frames.is_empty()
+    }
+
+    pub fn push(&mut self, frame: RawFrame, regions: DetectedRegions) {
+        if self.frames.len() == self.capacity_frames {
+            self.frames.pop_front();
+        }
+        self.frames.push_back(BufferedFrame { frame, regions });
+    }
+
+    pub fn add_manual_region_to_recent(&mut self, region: SensitiveMatch, recent_frames: usize) {
+        let count = recent_frames.min(self.frames.len());
+        let start = self.frames.len().saturating_sub(count);
+        for buffered in self.frames.iter_mut().skip(start) {
+            buffered.regions.matches.push(region.clone());
+        }
+    }
+
+    pub fn render_retroactive(
+        &self,
+        mode: TransformMode,
+        intensity: f32,
+    ) -> Result<Vec<TransformedFrame>> {
+        self.frames
+            .iter()
+            .map(|buffered| apply_transform(&buffered.frame, &buffered.regions, mode, intensity))
+            .collect()
+    }
+
+    pub fn estimated_memory_bytes(&self) -> Result<u64> {
+        let Some(first) = self.frames.front() else {
+            return Ok(0);
+        };
+        estimate_raw_rgba_memory_bytes(first.frame.width, first.frame.height, self.capacity_frames)
+    }
+}
+
+pub fn estimate_raw_rgba_memory_bytes(width: u32, height: u32, frames: usize) -> Result<u64> {
+    let frame_bytes = width
+        .checked_mul(height)
+        .and_then(|pixels| pixels.checked_mul(4))
+        .ok_or_else(|| anyhow!("frame dimensions are too large: {}x{}", width, height))?
+        as u64;
+    frame_bytes
+        .checked_mul(frames as u64)
+        .ok_or_else(|| anyhow!("frame buffer estimate overflowed"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use privacy_common::{detection::Severity, frame::Rect};
+
+    #[test]
+    fn buffer_keeps_only_recent_frames() {
+        let mut buffer = TimeMachineBuffer::new(1, 2);
+        buffer.push(solid_frame(1, 4, 4), DetectedRegions::default());
+        buffer.push(solid_frame(2, 4, 4), DetectedRegions::default());
+        buffer.push(solid_frame(3, 4, 4), DetectedRegions::default());
+
+        assert_eq!(buffer.capacity_frames(), 2);
+        assert_eq!(buffer.len(), 2);
+        assert_eq!(buffer.frames.front().unwrap().frame.pixels[0], 2);
+    }
+
+    #[test]
+    fn estimates_raw_rgba_memory() {
+        let bytes = estimate_raw_rgba_memory_bytes(1920, 1080, 30 * 30).unwrap();
+        assert_eq!(bytes, 1920 * 1080 * 4 * 900);
+    }
+
+    #[test]
+    fn manual_region_retroactively_transforms_buffered_frames() {
+        let mut buffer = TimeMachineBuffer::new(30, 1);
+        let original = gradient_frame(32, 24);
+        buffer.push(original.clone(), DetectedRegions::default());
+        buffer.add_manual_region_to_recent(manual_match(), 1);
+
+        let rendered = buffer
+            .render_retroactive(TransformMode::Pixelate, 1.0)
+            .unwrap();
+
+        assert_eq!(rendered.len(), 1);
+        assert_ne!(rendered[0].pixels, original.pixels);
+    }
+
+    #[test]
+    fn empty_buffer_reports_zero_memory() {
+        let buffer = TimeMachineBuffer::new(30, 30);
+        assert_eq!(buffer.estimated_memory_bytes().unwrap(), 0);
+    }
+
+    fn manual_match() -> SensitiveMatch {
+        SensitiveMatch {
+            bounds: Rect {
+                x: 4,
+                y: 4,
+                width: 16,
+                height: 12,
+            },
+            pattern_name: "manual-time-machine-region".to_string(),
+            severity: Severity::High,
+            snippet: "manual".to_string(),
+        }
+    }
+
+    fn solid_frame(value: u8, width: u32, height: u32) -> RawFrame {
+        RawFrame {
+            pixels: vec![value; (width * height * 4) as usize],
+            width,
+            height,
+            timestamp: chrono::Utc::now(),
+        }
+    }
+
+    fn gradient_frame(width: u32, height: u32) -> RawFrame {
+        let mut pixels = Vec::with_capacity((width * height * 4) as usize);
+        for y in 0..height {
+            for x in 0..width {
+                pixels.push(((x * 7) % 255) as u8);
+                pixels.push(((y * 11) % 255) as u8);
+                pixels.push((((x + y) * 5) % 255) as u8);
+                pixels.push(255);
+            }
+        }
+        RawFrame {
+            pixels,
+            width,
+            height,
+            timestamp: chrono::Utc::now(),
+        }
+    }
+}


### PR DESCRIPTION
Closes #21

## Summary
- add a `TimeMachineBuffer` prototype that retains recent raw frames in a bounded ring buffer
- support manual missed-region application and retroactive re-rendering through the existing transform registry
- document recording-only UX boundaries plus raw memory and disk implications

## Validation
- `cargo fmt --all`
- `cargo test -p privacy-core time_machine -- --nocapture`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all`
- `git diff --check`