### PR TITLE
[codex] add direct MP4 output sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2575,6 +2575,7 @@ dependencies = [
  "log",
  "privacy-common",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tray-item",

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ $ aki doctor
 $ aki test-patterns "SECRET_KEY=abc123"
 $ aki demo --frames 1 --no-clear
 $ aki redact ./recording.mov --output ./recording.redacted.mov
+$ aki --headless --source screen --record-output ./recording.redacted.mp4
 $ aki check-output
 $ aki --headless --source screen
 ```
@@ -119,6 +120,19 @@ The command decodes the first video stream with `ffmpeg`, runs the same local OC
 When `--output` is omitted, `Aki` writes next to the input as `<name>.redacted.<ext>`. Existing output files are refused unless `--overwrite` is passed, and the input file is never used as the output path.
 
 The recording-only time-machine buffer prototype is documented in [`docs/time-machine-buffer.md`](./docs/time-machine-buffer.md). It can re-render buffered local-recording frames before finalization, but it cannot unsend live-stream or screen-share pixels.
+
+### Direct MP4 Recording
+
+Use direct MP4 output when you want a local redacted screen recording without OBS, a virtual camera, or a separate screen-recording app:
+
+```console
+$ aki --headless --source screen --record-output ./recording.redacted.mp4
+$ aki --headless --source screen --output mp4 --record-output ./recording.redacted.mp4 --transform ascii
+```
+
+Recording starts when the first transformed frame is produced. Press `Ctrl-C` to stop capture, flush ffmpeg, and finalize the MP4. The output path must be explicit and end in `.mp4`; existing files are refused unless `--record-overwrite` is passed.
+
+Use the virtual camera, OBS, or MJPEG outputs for live streams and screen-share calls. Use direct MP4 when the final deliverable is a local recording file.
 
 ## Power-User / Developer Commands
 

--- a/privacy-output/Cargo.toml
+++ b/privacy-output/Cargo.toml
@@ -13,6 +13,9 @@ tokio = { workspace = true }
 image = { workspace = true }
 serde_json = { workspace = true }
 
+[dev-dependencies]
+tempfile = "3.26.0"
+
 [target.'cfg(target_os = "linux")'.dependencies]
 v4l = "0.14"
 

--- a/privacy-output/src/lib.rs
+++ b/privacy-output/src/lib.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use privacy_common::frame::TransformedFrame;
+use std::path::PathBuf;
 
 pub trait OutputSink: Send {
     fn write_frame(&mut self, frame: &TransformedFrame) -> Result<()>;
@@ -33,6 +34,12 @@ pub enum SinkKind {
     Obs(u16),
     /// Twitch RTMP output (planned): stream filtered output to rtmp://live.twitch.tv/app/<key>
     Twitch,
+    /// Direct local MP4 recording through ffmpeg.
+    Mp4 {
+        path: PathBuf,
+        fps: u32,
+        overwrite: bool,
+    },
 }
 
 /// Create the appropriate `OutputSink` boxed trait object from a `SinkKind`.
@@ -61,6 +68,12 @@ pub fn create_sink(kind: SinkKind) -> Result<Box<dyn OutputSink>> {
             // planned: RTMP output via ffmpeg/gstreamer to rtmp://live.twitch.tv/app/<key>
             anyhow::bail!("Twitch RTMP output is not yet implemented; planned feature")
         }
+
+        SinkKind::Mp4 {
+            path,
+            fps,
+            overwrite,
+        } => Ok(Box::new(recorder::Mp4Sink::new(path, fps, overwrite)?)),
 
         // Fall through for unsupported platform/kind combos
         #[allow(unreachable_patterns)]

--- a/privacy-output/src/recorder.rs
+++ b/privacy-output/src/recorder.rs
@@ -4,10 +4,14 @@
 use anyhow::{bail, Context, Result};
 use privacy_common::frame::TransformedFrame;
 use std::{
+    fs,
     io::Write,
+    path::{Path, PathBuf},
     process::{Child, ChildStdin, Command, Stdio},
     time::Instant,
 };
+
+use crate::OutputSink;
 
 pub struct Recorder {
     proc: Child,
@@ -20,18 +24,34 @@ impl Recorder {
     /// Spawn an ffmpeg process writing to `path` (e.g. "recording.mp4").
     /// `width`/`height` must match the frames that will be fed via `write_frame`.
     pub fn start(path: impl Into<String>, width: u32, height: u32, fps: u32) -> Result<Self> {
+        Self::start_with_overwrite(path, width, height, fps, true)
+    }
+
+    pub fn start_with_overwrite(
+        path: impl Into<String>,
+        width: u32,
+        height: u32,
+        fps: u32,
+        overwrite: bool,
+    ) -> Result<Self> {
         let path = path.into();
+        let video_size = format!("{}x{}", width, height);
+        let fps = fps.to_string();
+        let overwrite_flag = if overwrite { "-y" } else { "-n" };
         let mut child = Command::new("ffmpeg")
             .args([
-                "-y", // overwrite output
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                overwrite_flag,
                 "-f",
                 "rawvideo",
                 "-pixel_format",
                 "rgba",
                 "-video_size",
-                &format!("{}x{}", width, height),
+                &video_size,
                 "-framerate",
-                &fps.to_string(),
+                &fps,
                 "-i",
                 "pipe:0", // read from stdin
                 "-c:v",
@@ -72,5 +92,207 @@ impl Recorder {
             bail!("ffmpeg encoder exited with status {status}");
         }
         Ok(self.path)
+    }
+}
+
+pub struct Mp4Sink {
+    path: PathBuf,
+    fps: u32,
+    overwrite: bool,
+    recorder: Option<Recorder>,
+    width: u32,
+    height: u32,
+}
+
+impl Mp4Sink {
+    pub fn new(path: impl Into<PathBuf>, fps: u32, overwrite: bool) -> Result<Self> {
+        let path = path.into();
+        validate_mp4_output_path(&path, overwrite)?;
+        Ok(Self {
+            path,
+            fps: fps.clamp(1, 240),
+            overwrite,
+            recorder: None,
+            width: 0,
+            height: 0,
+        })
+    }
+
+    pub fn output_path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn is_started(&self) -> bool {
+        self.recorder.is_some()
+    }
+
+    fn start_for_frame(&mut self, frame: &TransformedFrame) -> Result<()> {
+        validate_frame_shape(frame)?;
+        validate_mp4_output_path(&self.path, self.overwrite)?;
+        let recorder = Recorder::start_with_overwrite(
+            self.path.to_string_lossy().to_string(),
+            frame.width,
+            frame.height,
+            self.fps,
+            self.overwrite,
+        )?;
+        self.width = frame.width;
+        self.height = frame.height;
+        self.recorder = Some(recorder);
+        Ok(())
+    }
+}
+
+impl OutputSink for Mp4Sink {
+    fn write_frame(&mut self, frame: &TransformedFrame) -> Result<()> {
+        validate_frame_shape(frame)?;
+        if self.recorder.is_none() {
+            self.start_for_frame(frame)?;
+        }
+        if frame.width != self.width || frame.height != self.height {
+            bail!(
+                "MP4 sink cannot change frame size mid-recording: started at {}x{}, got {}x{}",
+                self.width,
+                self.height,
+                frame.width,
+                frame.height
+            );
+        }
+        let recorder = self
+            .recorder
+            .as_mut()
+            .context("MP4 recorder did not start")?;
+        recorder.write_frame(frame)
+    }
+
+    fn close(&mut self) -> Result<()> {
+        if let Some(recorder) = self.recorder.take() {
+            recorder.stop()?;
+        }
+        Ok(())
+    }
+}
+
+fn validate_mp4_output_path(path: &Path, overwrite: bool) -> Result<()> {
+    if path.as_os_str().is_empty() {
+        bail!("MP4 output path must be explicit");
+    }
+    let extension = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or_default();
+    if !extension.eq_ignore_ascii_case("mp4") {
+        bail!("MP4 output path must end in .mp4: {}", path.display());
+    }
+    if path.is_dir() {
+        bail!("MP4 output path is a directory: {}", path.display());
+    }
+    if path.exists() && !overwrite {
+        bail!(
+            "MP4 output already exists: {} (pass --record-overwrite to replace it)",
+            path.display()
+        );
+    }
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("creating MP4 output directory {}", parent.display()))?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_frame_shape(frame: &TransformedFrame) -> Result<()> {
+    let expected = frame
+        .width
+        .checked_mul(frame.height)
+        .and_then(|pixels| pixels.checked_mul(4))
+        .context("MP4 frame dimensions are too large")? as usize;
+    if frame.pixels.len() != expected {
+        bail!(
+            "invalid RGBA frame for MP4 sink: {} bytes for {}x{} frame, expected {}",
+            frame.pixels.len(),
+            frame.width,
+            frame.height,
+            expected
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Stdio;
+    use tempfile::tempdir;
+
+    #[test]
+    fn mp4_sink_requires_mp4_extension() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("recording.mov");
+
+        assert!(Mp4Sink::new(path, 30, false).is_err());
+    }
+
+    #[test]
+    fn mp4_sink_rejects_existing_output_without_overwrite() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("recording.mp4");
+        fs::write(&path, b"existing").unwrap();
+
+        assert!(Mp4Sink::new(&path, 30, false).is_err());
+        assert!(Mp4Sink::new(&path, 30, true).is_ok());
+    }
+
+    #[test]
+    fn mp4_sink_starts_lazily() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nested").join("recording.mp4");
+        let mut sink = Mp4Sink::new(&path, 30, false).unwrap();
+
+        assert_eq!(sink.output_path(), path.as_path());
+        assert!(!sink.is_started());
+        assert!(!path.exists());
+        sink.close().unwrap();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn mp4_sink_writes_generated_frame_when_ffmpeg_available() {
+        if !tool_available("ffmpeg") {
+            eprintln!("skipping MP4 sink smoke test because ffmpeg is unavailable");
+            return;
+        }
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("recording.mp4");
+        let mut sink = Mp4Sink::new(&path, 1, false).unwrap();
+        let frame = solid_frame(64, 48);
+
+        sink.write_frame(&frame).unwrap();
+        assert!(sink.is_started());
+        sink.close().unwrap();
+
+        assert!(path.exists());
+        assert!(fs::metadata(path).unwrap().len() > 0);
+    }
+
+    fn solid_frame(width: u32, height: u32) -> TransformedFrame {
+        TransformedFrame {
+            pixels: vec![200u8; (width * height * 4) as usize],
+            width,
+            height,
+            timestamp: chrono::Utc::now(),
+        }
+    }
+
+    fn tool_available(name: &str) -> bool {
+        Command::new(name)
+            .arg("-version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
     }
 }

--- a/privacy-tui/src/main.rs
+++ b/privacy-tui/src/main.rs
@@ -22,7 +22,7 @@ const TICK_RATE: Duration = Duration::from_millis(100); // 10 Hz
 #[derive(Parser)]
 #[command(name = "aki", about = "Real-time privacy filter for screen capture")]
 struct Cli {
-    /// Run without TUI (headless mode) — log stats to file, output to virtual camera only.
+    /// Run without TUI (headless mode) — log stats to file and write to the selected output sink.
     #[arg(long)]
     headless: bool,
     /// Capture source for sidecar/headless runs.
@@ -40,6 +40,15 @@ struct Cli {
     /// HTTP MJPEG port used when the output sink needs one.
     #[arg(long, default_value_t = 9876)]
     http_port: u16,
+    /// Explicit MP4 path for direct local recording. Implies --output mp4 when --output is omitted.
+    #[arg(long, value_name = "PATH")]
+    record_output: Option<PathBuf>,
+    /// MP4 recording frame rate for --output mp4.
+    #[arg(long, default_value_t = 30)]
+    record_fps: u32,
+    /// Allow --output mp4 to replace an existing --record-output file.
+    #[arg(long)]
+    record_overwrite: bool,
     #[command(subcommand)]
     command: Option<Command>,
 }
@@ -90,6 +99,7 @@ enum CliOutput {
     Coremedia,
     Mjpeg,
     Obs,
+    Mp4,
 }
 
 #[derive(Debug, Subcommand)]
@@ -158,7 +168,15 @@ fn main() -> Result<()> {
         cli.command
     );
     if cli.headless {
-        return cmd_headless(source, cli.transform, cli.output, cli.http_port);
+        return cmd_headless(
+            source,
+            cli.transform,
+            cli.output,
+            cli.http_port,
+            cli.record_output,
+            cli.record_fps,
+            cli.record_overwrite,
+        );
     }
     match cli.command.unwrap_or(Command::Run) {
         Command::Run => cmd_run(source.uses_pty()),
@@ -202,13 +220,16 @@ fn cmd_headless(
     transform: Option<CliTransform>,
     output: Option<CliOutput>,
     http_port: u16,
+    record_output: Option<PathBuf>,
+    record_fps: u32,
+    record_overwrite: bool,
 ) -> Result<()> {
     use crossbeam_channel::bounded;
     use privacy_common::frame::TransformedFrame;
     use privacy_core::{
         config::AppConfig, detection::registry::runtime_registry, pipeline_runner::spawn_pipeline,
     };
-    use privacy_output::{autodetect::detect_best_sink, create_sink, SinkKind};
+    use privacy_output::create_sink;
     use std::sync::{
         atomic::{AtomicBool, Ordering},
         Arc, Mutex,
@@ -225,13 +246,13 @@ fn cmd_headless(
     })
     .unwrap_or_else(|_| log::warn!("failed to set Ctrl-C handler"));
 
-    let output_choice = output.unwrap_or(CliOutput::Auto);
-    let sink_kind = match output_choice {
-        CliOutput::Auto => detect_best_sink(http_port),
-        CliOutput::Coremedia => SinkKind::CoreMedia,
-        CliOutput::Mjpeg => SinkKind::HttpMjpeg(http_port),
-        CliOutput::Obs => SinkKind::Obs(http_port),
-    };
+    let sink_kind = resolve_headless_sink(
+        output,
+        http_port,
+        record_output,
+        record_fps,
+        record_overwrite,
+    )?;
     let output_label = sink_kind_label(&sink_kind);
     let sink = Arc::new(Mutex::new(create_sink(sink_kind)?));
     let cfg = AppConfig::load().unwrap_or_default();
@@ -275,7 +296,12 @@ fn cmd_headless(
         apply_headless_control(&control_state, &handle.state);
         if let Ok(frame) = out_rx.recv_timeout(Duration::from_millis(200)) {
             if let Ok(mut s) = sink.lock() {
-                let _ = s.write_frame(&frame);
+                if let Err(e) = s.write_frame(&frame) {
+                    log::error!("headless output write failed: {e}");
+                    eprintln!("output write failed: {e}");
+                    running.store(false, Ordering::SeqCst);
+                    break;
+                }
             }
             frame_count += 1;
         }
@@ -316,6 +342,12 @@ fn cmd_headless(
     }
 
     handle.shutdown();
+    {
+        let mut sink = sink
+            .lock()
+            .map_err(|_| anyhow::anyhow!("output sink lock poisoned during shutdown"))?;
+        sink.close()?;
+    }
     log::info!("headless mode stopped");
     Ok(())
 }
@@ -327,7 +359,46 @@ fn sink_kind_label(sink_kind: &privacy_output::SinkKind) -> String {
         privacy_output::SinkKind::HttpMjpeg(port) => format!("mjpeg:{port}"),
         privacy_output::SinkKind::Obs(port) => format!("obs:{port}"),
         privacy_output::SinkKind::Twitch => "twitch".to_string(),
+        privacy_output::SinkKind::Mp4 { path, .. } => format!("mp4:{}", path.display()),
     }
+}
+
+fn resolve_headless_sink(
+    output: Option<CliOutput>,
+    http_port: u16,
+    record_output: Option<PathBuf>,
+    record_fps: u32,
+    record_overwrite: bool,
+) -> Result<privacy_output::SinkKind> {
+    use privacy_output::{autodetect::detect_best_sink, SinkKind};
+
+    if !(1..=240).contains(&record_fps) {
+        bail!("--record-fps must be between 1 and 240");
+    }
+
+    let output_choice = match (output, record_output.is_some()) {
+        (Some(choice), _) => choice,
+        (None, true) => CliOutput::Mp4,
+        (None, false) => CliOutput::Auto,
+    };
+
+    if record_output.is_some() && !matches!(output_choice, CliOutput::Mp4) {
+        bail!("--record-output can only be used with --output mp4");
+    }
+
+    let sink = match output_choice {
+        CliOutput::Auto => detect_best_sink(http_port),
+        CliOutput::Coremedia => SinkKind::CoreMedia,
+        CliOutput::Mjpeg => SinkKind::HttpMjpeg(http_port),
+        CliOutput::Obs => SinkKind::Obs(http_port),
+        CliOutput::Mp4 => SinkKind::Mp4 {
+            path: record_output
+                .ok_or_else(|| anyhow::anyhow!("--output mp4 requires --record-output <PATH>"))?,
+            fps: record_fps,
+            overwrite: record_overwrite,
+        },
+    };
+    Ok(sink)
 }
 
 fn transform_mode_from_config(mode: &str) -> TransformMode {
@@ -792,6 +863,7 @@ fn cmd_check_output() -> Result<()> {
         SinkKind::HttpMjpeg(port) => println!("fallback: MJPEG HTTP on port {}", port),
         SinkKind::Obs(port) => println!("OBS WebSocket + MJPEG on port {}", port),
         SinkKind::Twitch => println!("Twitch RTMP (planned — not yet wired)"),
+        SinkKind::Mp4 { path, .. } => println!("MP4 recording output: {}", path.display()),
     }
     Ok(())
 }
@@ -1002,5 +1074,73 @@ fn handle_event(app: &mut app::App, ev: Event) {
             }
         }
         Event::Tick => app.tick_transition(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use privacy_output::SinkKind;
+
+    #[test]
+    fn record_output_infers_mp4_sink() {
+        let sink = resolve_headless_sink(
+            None,
+            9876,
+            Some(PathBuf::from("recording.redacted.mp4")),
+            24,
+            false,
+        )
+        .unwrap();
+
+        match sink {
+            SinkKind::Mp4 {
+                path,
+                fps,
+                overwrite,
+            } => {
+                assert_eq!(path, PathBuf::from("recording.redacted.mp4"));
+                assert_eq!(fps, 24);
+                assert!(!overwrite);
+            }
+            other => panic!("expected mp4 sink, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mp4_sink_requires_record_output_path() {
+        assert!(resolve_headless_sink(Some(CliOutput::Mp4), 9876, None, 30, false).is_err());
+    }
+
+    #[test]
+    fn record_output_rejects_non_mp4_sink_choice() {
+        assert!(resolve_headless_sink(
+            Some(CliOutput::Mjpeg),
+            9876,
+            Some(PathBuf::from("recording.redacted.mp4")),
+            30,
+            false,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn record_fps_must_be_reasonable() {
+        assert!(resolve_headless_sink(
+            Some(CliOutput::Mp4),
+            9876,
+            Some(PathBuf::from("recording.redacted.mp4")),
+            0,
+            false,
+        )
+        .is_err());
+        assert!(resolve_headless_sink(
+            Some(CliOutput::Mp4),
+            9876,
+            Some(PathBuf::from("recording.redacted.mp4")),
+            241,
+            false,
+        )
+        .is_err());
     }
 }

--- a/privacy-tui/src/ui/stats_bar.rs
+++ b/privacy-tui/src/ui/stats_bar.rs
@@ -79,6 +79,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                 Some(SinkKind::HttpMjpeg(port)) => format!("  │  sink:mjpeg:{}", port),
                 Some(SinkKind::Obs(port)) => format!("  │  sink:obs:{}", port),
                 Some(SinkKind::Twitch) => "  │  sink:twitch(planned)".to_string(),
+                Some(SinkKind::Mp4 { path, .. }) => format!("  │  sink:mp4:{}", path.display()),
                 None => String::new(),
             };
             Span::styled(sink_str, Style::default().fg(Color::DarkGray))


### PR DESCRIPTION
Closes #22

## Summary
- add a direct MP4 `OutputSink` that pipes transformed frames through ffmpeg and finalizes on sink close
- expose headless recording via `--output mp4` / `--record-output`, with explicit `.mp4` path validation and opt-in overwrite
- document when to use direct MP4 recording instead of virtual camera, OBS, or MJPEG output

## Validation
- `cargo fmt --all`
- `cargo test -p privacy-output recorder -- --nocapture`
- `cargo test -p privacy-tui record_ -- --nocapture`
- `cargo run -p privacy-tui -- --help`
- `cargo run -p privacy-tui -- --headless --output mp4`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all`
- `git diff --check`