### PR TITLE
[codex] add multi-display capture support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ macOS DMG release packaging is documented in [`docs/macos-release.md`](./docs/ma
 
 ```console
 $ aki list-windows
+$ aki list-displays
 $ aki doctor
 $ aki test-patterns "SECRET_KEY=abc123"
 $ aki demo --frames 1 --no-clear
@@ -133,6 +134,18 @@ $ aki --headless --source screen --output mp4 --record-output ./recording.redact
 Recording starts when the first transformed frame is produced. Press `Ctrl-C` to stop capture, flush ffmpeg, and finalize the MP4. The output path must be explicit and end in `.mp4`; existing files are refused unless `--record-overwrite` is passed.
 
 Use the virtual camera, OBS, or MJPEG outputs for live streams and screen-share calls. Use direct MP4 when the final deliverable is a local recording file.
+
+### Multi-Display Capture
+
+Use `aki list-displays` to find display indexes, then pass `--display` once for a specific display or more than once for side-by-side multi-display capture:
+
+```console
+$ aki list-displays
+$ aki --headless --source screen --display 1
+$ aki --headless --source screen --display 0 --display 1 --record-output ./multi-display.redacted.mp4
+```
+
+The behavior, hot-plug expectations, and performance costs are documented in [`docs/multi-display-capture.md`](./docs/multi-display-capture.md).
 
 ## Power-User / Developer Commands
 

--- a/docs/multi-display-capture.md
+++ b/docs/multi-display-capture.md
@@ -1,0 +1,58 @@
+# Multi-Display Capture
+
+Multi-display capture lets `Aki` read one or more full displays instead of a single window or the primary display.
+
+## Commands
+
+List currently available displays:
+
+```console
+$ aki list-displays
+```
+
+Capture a specific display:
+
+```console
+$ aki --headless --source screen --display 1
+```
+
+Capture multiple displays into one redacted output canvas:
+
+```console
+$ aki --headless --source screen --display 0 --display 1
+$ aki --headless --source screen --display 0,1 --record-output ./multi-display.redacted.mp4
+```
+
+The `--display` flag can be repeated or comma-separated. It is only valid with screen capture; PTY capture rejects display indexes.
+
+## Layout
+
+Multiple selected displays are composed left-to-right in the order provided on the command line. `--display 1 --display 0` intentionally produces a different canvas from `--display 0 --display 1`.
+
+Displays are not scaled. Shorter displays are padded with opaque black pixels below their frame so OCR, transforms, and output sinks receive one stable RGBA canvas.
+
+## Connect And Disconnect Behavior
+
+Display indexes are resolved from the display list at startup. Run `aki list-displays` after connecting or removing monitors, then restart capture with the desired indexes.
+
+If a requested display index is not present at startup, capture fails instead of silently choosing another display.
+
+If a display is disconnected while capture is running, `Aki` does not silently remap that slot to a different display. The active capture either reports a capture error or stops producing new frames for that display; restart capture after running `aki list-displays`.
+
+## Performance Impact
+
+Multi-display capture increases the canvas that OCR and transforms must inspect. The compositor emits raw RGBA frames at the combined width and maximum height of the selected displays.
+
+At 30 FPS, approximate raw RGBA throughput is:
+
+| Selection | Output canvas | Bytes per frame | Raw RGBA throughput |
+|-----------|---------------|-----------------|---------------------|
+| 1x 1080p | 1920x1080 | 8,294,400 | 237.3 MiB/s |
+| 2x 1080p | 3840x1080 | 16,588,800 | 474.6 MiB/s |
+| 1x 1440p | 2560x1440 | 14,745,600 | 421.9 MiB/s |
+| 2x 1440p | 5120x1440 | 29,491,200 | 843.8 MiB/s |
+| 1x 4K | 3840x2160 | 33,177,600 | 949.2 MiB/s |
+| 2x 4K | 7680x2160 | 66,355,200 | 1.85 GiB/s |
+| 1080p + 1440p | 4480x1440 | 25,804,800 | 738.3 MiB/s |
+
+These numbers are only the raw canvas bytes moving through the pipeline. OCR, redaction transforms, preview cloning, MP4 encoding, and output sinks add work on top. For CPU-bound setups, start with one display or reduce capture FPS before trying two 4K displays.

--- a/docs/sidecar-protocol.md
+++ b/docs/sidecar-protocol.md
@@ -15,10 +15,11 @@ This keeps the shipped Rust pipeline as the single implementation, avoids ABI an
 The menu-bar app starts the sidecar with:
 
 ```console
-aki --headless --source screen|pty --transform blur|pixelate|cartoon|ascii|neural --output auto|coremedia|mjpeg|obs --http-port 9876
+aki --headless --source screen|pty --display 0 --transform blur|pixelate|cartoon|ascii|neural --output auto|coremedia|mjpeg|obs|mp4 --http-port 9876
 ```
 
 `--pty` remains as a compatibility alias for `--source pty`, but the menu-bar app uses `--source` so source selection is explicit.
+`--display` is optional, can be repeated for multi-display capture, and is only valid with `--source screen`. `--output mp4` requires an explicit `--record-output <PATH>`.
 
 Start and stop are process lifecycle operations:
 

--- a/privacy-core/src/capture/mod.rs
+++ b/privacy-core/src/capture/mod.rs
@@ -17,6 +17,7 @@ pub mod linux;
 pub use linux::x11::X11CaptureSource;
 
 pub mod fps;
+pub mod multi_display;
 pub mod pty;
 pub mod region;
 pub mod window_picker;

--- a/privacy-core/src/capture/multi_display.rs
+++ b/privacy-core/src/capture/multi_display.rs
@@ -1,0 +1,271 @@
+use anyhow::{anyhow, bail, Context, Result};
+use privacy_common::frame::{RawFrame, WindowInfo};
+
+use super::CaptureSource;
+
+/// One selected display and its platform capture source.
+pub struct DisplayCapture {
+    pub label: String,
+    source: Box<dyn CaptureSource + Send>,
+    last_frame: Option<RawFrame>,
+}
+
+impl DisplayCapture {
+    pub fn new(label: impl Into<String>, source: Box<dyn CaptureSource + Send>) -> Self {
+        Self {
+            label: label.into(),
+            source,
+            last_frame: None,
+        }
+    }
+}
+
+/// Captures multiple displays and emits a single side-by-side RGBA frame.
+pub struct MultiDisplayCaptureSource {
+    displays: Vec<DisplayCapture>,
+}
+
+impl MultiDisplayCaptureSource {
+    pub fn new(displays: Vec<DisplayCapture>) -> Self {
+        Self { displays }
+    }
+
+    pub fn display_count(&self) -> usize {
+        self.displays.len()
+    }
+}
+
+impl CaptureSource for MultiDisplayCaptureSource {
+    fn start(&mut self) -> Result<()> {
+        if self.displays.is_empty() {
+            bail!("multi-display capture requires at least one display");
+        }
+
+        for idx in 0..self.displays.len() {
+            if let Err(err) = self.displays[idx].source.start() {
+                for display in self.displays.iter_mut().take(idx) {
+                    let _ = display.source.stop();
+                }
+                bail!("starting {}: {err}", self.displays[idx].label);
+            }
+        }
+        Ok(())
+    }
+
+    fn stop(&mut self) -> Result<()> {
+        let mut first_error = None;
+        for display in &mut self.displays {
+            if let Err(err) = display.source.stop() {
+                first_error.get_or_insert_with(|| anyhow!("stopping {}: {err}", display.label));
+            }
+            display.last_frame = None;
+        }
+        if let Some(err) = first_error {
+            return Err(err);
+        }
+        Ok(())
+    }
+
+    fn next_frame(&mut self) -> Result<Option<RawFrame>> {
+        let mut updated = false;
+        for display in &mut self.displays {
+            match display.source.next_frame() {
+                Ok(Some(frame)) => {
+                    display.last_frame = Some(frame);
+                    updated = true;
+                }
+                Ok(None) => {}
+                Err(err) => bail!("reading {}: {err}", display.label),
+            }
+        }
+
+        if !updated {
+            return Ok(None);
+        }
+
+        let frames: Vec<_> = self
+            .displays
+            .iter()
+            .map(|display| display.last_frame.as_ref())
+            .collect();
+        let Some(frames) = frames.into_iter().collect::<Option<Vec<_>>>() else {
+            return Ok(None);
+        };
+        Ok(Some(compose_horizontal(&frames)?))
+    }
+
+    fn list_windows(&self) -> Result<Vec<WindowInfo>> {
+        Ok(Vec::new())
+    }
+}
+
+pub fn compose_horizontal(frames: &[&RawFrame]) -> Result<RawFrame> {
+    if frames.is_empty() {
+        bail!("cannot compose zero display frames");
+    }
+
+    let width = frames.iter().try_fold(0u32, |sum, frame| {
+        sum.checked_add(frame.width)
+            .ok_or_else(|| anyhow!("multi-display width overflowed"))
+    })?;
+    let height = frames
+        .iter()
+        .map(|frame| frame.height)
+        .max()
+        .context("cannot compose zero display frames")?;
+    let output_len = rgba_len(width, height)? as usize;
+    let mut pixels = vec![0u8; output_len];
+    for chunk in pixels.chunks_exact_mut(4) {
+        chunk[3] = 255;
+    }
+
+    let mut x_offset = 0u32;
+    for frame in frames {
+        let expected = rgba_len(frame.width, frame.height)? as usize;
+        if frame.pixels.len() != expected {
+            bail!(
+                "display frame has {} bytes for {}x{}, expected {}",
+                frame.pixels.len(),
+                frame.width,
+                frame.height,
+                expected
+            );
+        }
+        copy_frame(&mut pixels, width, frame, x_offset)?;
+        x_offset += frame.width;
+    }
+
+    Ok(RawFrame {
+        pixels,
+        width,
+        height,
+        timestamp: chrono::Utc::now(),
+    })
+}
+
+pub fn estimate_raw_rgba_bytes_per_second(displays: &[(u32, u32)], fps: u32) -> Result<u64> {
+    let cost = estimate_composited_canvas(displays)?;
+    cost.composited_bytes
+        .checked_mul(fps as u64)
+        .ok_or_else(|| anyhow!("multi-display throughput estimate overflowed"))
+}
+
+pub fn estimate_composited_canvas(displays: &[(u32, u32)]) -> Result<CompositedCanvasEstimate> {
+    if displays.is_empty() {
+        bail!("at least one display is required");
+    }
+    let width = displays.iter().try_fold(0u32, |sum, (w, _)| {
+        sum.checked_add(*w)
+            .ok_or_else(|| anyhow!("multi-display width overflowed"))
+    })?;
+    let height = displays
+        .iter()
+        .map(|(_, h)| *h)
+        .max()
+        .context("at least one display is required")?;
+    let source_bytes = displays.iter().try_fold(0u64, |sum, (w, h)| {
+        sum.checked_add(rgba_len(*w, *h)?)
+            .ok_or_else(|| anyhow!("source byte estimate overflowed"))
+    })?;
+    let composited_bytes = rgba_len(width, height)?;
+    Ok(CompositedCanvasEstimate {
+        width,
+        height,
+        source_bytes,
+        composited_bytes,
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompositedCanvasEstimate {
+    pub width: u32,
+    pub height: u32,
+    pub source_bytes: u64,
+    pub composited_bytes: u64,
+}
+
+fn copy_frame(output: &mut [u8], output_width: u32, frame: &RawFrame, x_offset: u32) -> Result<()> {
+    let output_stride = output_width as usize * 4;
+    let frame_stride = frame.width as usize * 4;
+    let x_offset_bytes = x_offset as usize * 4;
+
+    for row in 0..frame.height as usize {
+        let src_start = row * frame_stride;
+        let dst_start = row * output_stride + x_offset_bytes;
+        let src_end = src_start + frame_stride;
+        let dst_end = dst_start + frame_stride;
+        output
+            .get_mut(dst_start..dst_end)
+            .context("multi-display copy exceeded output frame bounds")?
+            .copy_from_slice(&frame.pixels[src_start..src_end]);
+    }
+    Ok(())
+}
+
+fn rgba_len(width: u32, height: u32) -> Result<u64> {
+    width
+        .checked_mul(height)
+        .and_then(|pixels| pixels.checked_mul(4))
+        .map(u64::from)
+        .ok_or_else(|| anyhow!("RGBA dimensions are too large: {width}x{height}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn composes_frames_side_by_side() {
+        let left = solid_frame(2, 1, [255, 0, 0, 255]);
+        let right = solid_frame(1, 2, [0, 0, 255, 255]);
+
+        let composed = compose_horizontal(&[&left, &right]).unwrap();
+
+        assert_eq!(composed.width, 3);
+        assert_eq!(composed.height, 2);
+        assert_eq!(&composed.pixels[0..4], &[255, 0, 0, 255]);
+        assert_eq!(&composed.pixels[4..8], &[255, 0, 0, 255]);
+        assert_eq!(&composed.pixels[8..12], &[0, 0, 255, 255]);
+        assert_eq!(&composed.pixels[12..16], &[0, 0, 0, 255]);
+        assert_eq!(&composed.pixels[20..24], &[0, 0, 255, 255]);
+    }
+
+    #[test]
+    fn estimates_composited_canvas_cost() {
+        let estimate = estimate_composited_canvas(&[(1920, 1080), (2560, 1440)]).unwrap();
+
+        assert_eq!(estimate.width, 4480);
+        assert_eq!(estimate.height, 1440);
+        assert_eq!(
+            estimate.source_bytes,
+            (1920 * 1080 * 4 + 2560 * 1440 * 4) as u64
+        );
+        assert_eq!(estimate.composited_bytes, 4480 * 1440 * 4);
+    }
+
+    #[test]
+    fn estimates_raw_throughput_at_fps() {
+        let bytes = estimate_raw_rgba_bytes_per_second(&[(1920, 1080), (1920, 1080)], 30).unwrap();
+
+        assert_eq!(bytes, 3840 * 1080 * 4 * 30);
+    }
+
+    #[test]
+    fn rejects_empty_display_estimate() {
+        assert!(estimate_composited_canvas(&[]).is_err());
+        assert!(compose_horizontal(&[]).is_err());
+    }
+
+    fn solid_frame(width: u32, height: u32, rgba: [u8; 4]) -> RawFrame {
+        let mut pixels = Vec::with_capacity((width * height * 4) as usize);
+        for _ in 0..width * height {
+            pixels.extend_from_slice(&rgba);
+        }
+        RawFrame {
+            pixels,
+            width,
+            height,
+            timestamp: chrono::Utc::now(),
+        }
+    }
+}

--- a/privacy-core/src/capture/window_picker.rs
+++ b/privacy-core/src/capture/window_picker.rs
@@ -8,6 +8,7 @@ use privacy_common::frame::{Rect, WindowInfo};
 #[derive(Debug, Clone)]
 pub struct DisplayInfo {
     pub index: usize,
+    pub id: u32,
     pub name: String,
     pub bounds: Rect,
     pub is_primary: bool,
@@ -62,21 +63,24 @@ pub fn list_displays() -> Result<Vec<DisplayInfo>> {
     #[cfg(target_os = "macos")]
     {
         use core_graphics::display::CGDisplay;
-        let ids = CGDisplay::active_displays()
-            .map_err(|e| anyhow::anyhow!("CGDisplay::active_displays: {:?}", e))?;
+        use screencapturekit::shareable_content::SCShareableContent;
+        let content = SCShareableContent::get()
+            .map_err(|e| anyhow::anyhow!("SCShareableContent::get: {:?}", e))?;
         let primary = CGDisplay::main().id;
-        let displays = ids
+        let displays = content
+            .displays()
             .into_iter()
             .enumerate()
-            .map(|(idx, id)| {
-                let d = CGDisplay::new(id);
-                let b = d.bounds();
+            .map(|(idx, display)| {
+                let id = display.display_id();
+                let b = display.frame();
                 DisplayInfo {
                     index: idx,
+                    id,
                     name: format!("Display {} (id={})", idx + 1, id),
                     bounds: Rect {
-                        x: b.origin.x as u32,
-                        y: b.origin.y as u32,
+                        x: b.origin.x.max(0.0) as u32,
+                        y: b.origin.y.max(0.0) as u32,
                         width: b.size.width as u32,
                         height: b.size.height as u32,
                     },
@@ -92,6 +96,7 @@ pub fn list_displays() -> Result<Vec<DisplayInfo>> {
         // X11: use XineramaQueryScreens or RandR for display info
         Ok(vec![DisplayInfo {
             index: 0,
+            id: 0,
             name: "Display 0 (X11)".into(),
             bounds: Rect {
                 x: 0,

--- a/privacy-tui/src/app.rs
+++ b/privacy-tui/src/app.rs
@@ -202,6 +202,8 @@ pub struct App {
     pub selected_window_id: Option<u64>,
     /// Title for the selected capture window, used as a fallback when foreground app detection is unavailable.
     pub selected_window_title: Option<String>,
+    /// Selected display indexes for full-display or multi-display capture.
+    pub selected_display_indexes: Vec<usize>,
     pub window_selector: crate::ui::window_selector::WindowSelectorState,
     pub pattern_manager: crate::ui::pattern_manager::PatternManagerState,
     pub pattern_registry: PatternRegistry,
@@ -302,6 +304,7 @@ impl App {
             preview_height: 0,
             selected_window_id: None,
             selected_window_title: None,
+            selected_display_indexes: Vec::new(),
             window_selector: crate::ui::window_selector::WindowSelectorState::new(),
             pattern_manager: crate::ui::pattern_manager::PatternManagerState::new(),
             pattern_registry,

--- a/privacy-tui/src/main.rs
+++ b/privacy-tui/src/main.rs
@@ -28,6 +28,9 @@ struct Cli {
     /// Capture source for sidecar/headless runs.
     #[arg(long, value_enum)]
     source: Option<CliSource>,
+    /// Display index to capture. Repeat or comma-separate for side-by-side multi-display capture.
+    #[arg(long = "display", value_name = "INDEX", value_delimiter = ',')]
+    display_indexes: Vec<usize>,
     /// Use PTY capture (compatibility alias for --source pty).
     #[arg(long)]
     pty: bool,
@@ -102,12 +105,25 @@ enum CliOutput {
     Mp4,
 }
 
+struct HeadlessOptions {
+    source_choice: CliSource,
+    display_indexes: Vec<usize>,
+    transform: Option<CliTransform>,
+    output: Option<CliOutput>,
+    http_port: u16,
+    record_output: Option<PathBuf>,
+    record_fps: u32,
+    record_overwrite: bool,
+}
+
 #[derive(Debug, Subcommand)]
 enum Command {
     /// Launch TUI + pipeline (default when no subcommand given).
     Run,
     /// Print all available capturable windows.
     ListWindows,
+    /// Print all available displays and their indexes.
+    ListDisplays,
     /// Run sensitivity patterns against provided text.
     TestPatterns {
         /// Text to test against all enabled patterns.
@@ -161,26 +177,30 @@ fn main() -> Result<()> {
     log::info!("log file ready at {}", log_path.display());
     let cli = Cli::parse();
     let source = resolve_source(cli.source, cli.pty)?;
+    let display_indexes = normalize_display_indexes(cli.display_indexes)?;
     log::info!(
-        "cli parsed headless={} source={} command={:?}",
+        "cli parsed headless={} source={} displays={:?} command={:?}",
         cli.headless,
         source.protocol_value(),
+        display_indexes,
         cli.command
     );
     if cli.headless {
-        return cmd_headless(
-            source,
-            cli.transform,
-            cli.output,
-            cli.http_port,
-            cli.record_output,
-            cli.record_fps,
-            cli.record_overwrite,
-        );
+        return cmd_headless(HeadlessOptions {
+            source_choice: source,
+            display_indexes,
+            transform: cli.transform,
+            output: cli.output,
+            http_port: cli.http_port,
+            record_output: cli.record_output,
+            record_fps: cli.record_fps,
+            record_overwrite: cli.record_overwrite,
+        });
     }
     match cli.command.unwrap_or(Command::Run) {
-        Command::Run => cmd_run(source.uses_pty()),
+        Command::Run => cmd_run(source.uses_pty(), display_indexes),
         Command::ListWindows => cmd_list_windows(),
+        Command::ListDisplays => cmd_list_displays(),
         Command::TestPatterns { text } => cmd_test_patterns(&text),
         Command::CheckOutput => cmd_check_output(),
         Command::Doctor { obs } => doctor::run_doctor(doctor::DoctorOptions { check_obs: obs }),
@@ -214,16 +234,20 @@ fn resolve_source(source: Option<CliSource>, pty: bool) -> Result<CliSource> {
     }
 }
 
+fn normalize_display_indexes(indexes: Vec<usize>) -> Result<Vec<usize>> {
+    let mut seen = std::collections::HashSet::new();
+    let mut normalized = Vec::with_capacity(indexes.len());
+    for index in indexes {
+        if !seen.insert(index) {
+            bail!("display index {index} was provided more than once");
+        }
+        normalized.push(index);
+    }
+    Ok(normalized)
+}
+
 /// Headless mode: full pipeline without TUI; logs stats to XDG config dir; Ctrl-C to stop.
-fn cmd_headless(
-    source_choice: CliSource,
-    transform: Option<CliTransform>,
-    output: Option<CliOutput>,
-    http_port: u16,
-    record_output: Option<PathBuf>,
-    record_fps: u32,
-    record_overwrite: bool,
-) -> Result<()> {
+fn cmd_headless(options: HeadlessOptions) -> Result<()> {
     use crossbeam_channel::bounded;
     use privacy_common::frame::TransformedFrame;
     use privacy_core::{
@@ -235,9 +259,25 @@ fn cmd_headless(
         Arc, Mutex,
     };
 
+    let HeadlessOptions {
+        source_choice,
+        display_indexes,
+        transform,
+        output,
+        http_port,
+        record_output,
+        record_fps,
+        record_overwrite,
+    } = options;
+
+    if source_choice.uses_pty() && !display_indexes.is_empty() {
+        bail!("--display can only be used with --source screen");
+    }
+
     log::info!(
-        "starting headless mode source={}",
-        source_choice.protocol_value()
+        "starting headless mode source={} displays={:?}",
+        source_choice.protocol_value(),
+        display_indexes
     );
     let running = Arc::new(AtomicBool::new(true));
     let r = running.clone();
@@ -261,14 +301,14 @@ fn cmd_headless(
         .unwrap_or_else(|| transform_mode_from_config(&cfg.transform.mode));
     let initial_intensity = cfg.transform.intensity.clamp(0.0, 1.0);
     let control_state = control_server::ControlState::new(initial_mode, initial_intensity);
-    control_state.set_source(source_choice.protocol_value());
+    control_state.set_source(&capture_source_label(source_choice, &display_indexes));
     control_state.set_output(&output_label);
     control_server::spawn(
         Arc::clone(&control_state),
         control_server::DEFAULT_CONTROL_PORT,
     );
     let registry = runtime_registry(&cfg);
-    let source = create_capture_source(None, source_choice.uses_pty());
+    let source = create_capture_source(None, source_choice.uses_pty(), &display_indexes);
     let (out_tx, out_rx) = bounded::<TransformedFrame>(8);
     let handle = spawn_pipeline(source, None, registry, out_tx)?;
     *handle.state.transform_mode.lock().unwrap() = initial_mode;
@@ -360,6 +400,22 @@ fn sink_kind_label(sink_kind: &privacy_output::SinkKind) -> String {
         privacy_output::SinkKind::Obs(port) => format!("obs:{port}"),
         privacy_output::SinkKind::Twitch => "twitch".to_string(),
         privacy_output::SinkKind::Mp4 { path, .. } => format!("mp4:{}", path.display()),
+    }
+}
+
+fn capture_source_label(source: CliSource, display_indexes: &[usize]) -> String {
+    match (source, display_indexes) {
+        (CliSource::Pty, _) => "pty".to_string(),
+        (CliSource::Screen, []) => "screen".to_string(),
+        (CliSource::Screen, [display]) => format!("screen:display:{display}"),
+        (CliSource::Screen, displays) => {
+            let joined = displays
+                .iter()
+                .map(|display| display.to_string())
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("screen:displays:{joined}")
+        }
     }
 }
 
@@ -511,13 +567,17 @@ fn export_session_log(app: &app::App) {
     }
 }
 
-fn cmd_run(use_pty: bool) -> Result<()> {
+fn cmd_run(use_pty: bool, display_indexes: Vec<usize>) -> Result<()> {
+    if use_pty && !display_indexes.is_empty() {
+        bail!("--display can only be used with --source screen");
+    }
     use privacy_output::{autodetect::detect_best_sink, create_sink, tray};
     use std::sync::{Arc, Mutex};
-    log::info!("starting tui mode use_pty={use_pty}");
+    log::info!("starting tui mode use_pty={use_pty} displays={display_indexes:?}");
     let mut terminal = tui::init()?;
     let mut app = app::App::new();
     app.use_pty = use_pty;
+    app.selected_display_indexes = display_indexes;
     auto_select_initial_window(&mut app);
     app.refresh_foreground_profile();
     let sink_kind = detect_best_sink(9876);
@@ -541,7 +601,7 @@ fn cmd_run(use_pty: bool) -> Result<()> {
 
 /// Pick a reasonable initial capture window to avoid display self-capture recursion.
 fn auto_select_initial_window(app: &mut app::App) {
-    if app.use_pty || app.selected_window_id.is_some() {
+    if app.use_pty || app.selected_window_id.is_some() || !app.selected_display_indexes.is_empty() {
         return;
     }
     let windows = privacy_core::capture::window_picker::list_windows().unwrap_or_default();
@@ -611,11 +671,16 @@ fn spawn_capture_pipeline(
     use privacy_common::frame::TransformedFrame;
     use privacy_core::pipeline_runner::spawn_pipeline;
     let (out_tx, out_rx) = bounded::<TransformedFrame>(8);
-    let source = create_capture_source(app.selected_window_id, app.use_pty);
+    let source = create_capture_source(
+        app.selected_window_id,
+        app.use_pty,
+        &app.selected_display_indexes,
+    );
     let registry = app.pattern_registry.clone();
     log::info!(
-        "spawn_capture_pipeline selected_window_id={:?} use_pty={}",
+        "spawn_capture_pipeline selected_window_id={:?} display_indexes={:?} use_pty={}",
         app.selected_window_id,
+        app.selected_display_indexes,
         app.use_pty
     );
     let handle = spawn_pipeline(source, None, registry, out_tx)?;
@@ -693,6 +758,7 @@ fn run_with_pipeline_restart(
 fn create_capture_source(
     window_id: Option<u64>,
     use_pty: bool,
+    display_indexes: &[usize],
 ) -> Box<dyn privacy_core::capture::CaptureSource + Send> {
     if use_pty {
         use privacy_core::capture::pty::PtyCaptureSource;
@@ -702,15 +768,38 @@ fn create_capture_source(
     #[cfg(target_os = "macos")]
     {
         use privacy_core::capture::macos::{CaptureTarget, MacosCaptureSource};
-        let target = window_id
-            .map(CaptureTarget::Window)
+        use privacy_core::capture::multi_display::{DisplayCapture, MultiDisplayCaptureSource};
+        if display_indexes.len() > 1 {
+            let displays = display_indexes
+                .iter()
+                .map(|index| {
+                    let source = MacosCaptureSource::new(CaptureTarget::Display(*index), 30);
+                    DisplayCapture::new(
+                        format!("display {index}"),
+                        Box::new(source) as Box<dyn privacy_core::capture::CaptureSource + Send>,
+                    )
+                })
+                .collect();
+            log::debug!("capture source selected: macos multi-display {display_indexes:?}");
+            return Box::new(MultiDisplayCaptureSource::new(displays));
+        }
+        let target = display_indexes
+            .first()
+            .copied()
+            .map(CaptureTarget::Display)
+            .or_else(|| window_id.map(CaptureTarget::Window))
             .unwrap_or(CaptureTarget::Display(0));
-        log::debug!("capture source selected: macos {:?}", window_id);
+        log::debug!(
+            "capture source selected: macos window={:?} displays={:?}",
+            window_id,
+            display_indexes
+        );
         return Box::new(MacosCaptureSource::new(target, 30));
     }
     #[allow(unreachable_code)]
     {
         let _ = window_id;
+        let _ = display_indexes;
         panic!("platform not supported");
     }
 }
@@ -726,6 +815,31 @@ fn cmd_list_windows() -> Result<()> {
         println!(
             "{:>8}  {:<40}  {}x{}",
             w.id, &w.title, w.bounds.width, w.bounds.height
+        );
+    }
+    Ok(())
+}
+
+fn cmd_list_displays() -> Result<()> {
+    let displays = privacy_core::capture::window_picker::list_displays()?;
+    if displays.is_empty() {
+        println!("no displays found");
+        return Ok(());
+    }
+    println!(
+        "{:>5}  {:>10}  {:<7}  {:>9}  NAME",
+        "INDEX", "ID", "PRIMARY", "WxH"
+    );
+    for display in displays {
+        let primary = if display.is_primary { "yes" } else { "" };
+        println!(
+            "{:>5}  {:>10}  {:<7}  {:>4}x{:<4}  {}",
+            display.index,
+            display.id,
+            primary,
+            display.bounds.width,
+            display.bounds.height,
+            display.name
         );
     }
     Ok(())
@@ -812,7 +926,7 @@ fn cmd_test_screen() -> Result<()> {
     let mut total_matches = 0usize;
     println!("capturing 10 frames for analysis...");
     // start a real capture from the first available window
-    let mut source = create_capture_source(Some(windows[0].id), false);
+    let mut source = create_capture_source(Some(windows[0].id), false, &[]);
     source.start()?;
     for i in 0..10 {
         // poll for a real frame (timeout ~500ms)
@@ -908,6 +1022,7 @@ fn handle_event(app: &mut app::App, ev: Event) {
                             log::info!("action:window_selector.select window_id={}", window.id);
                             app.selected_window_id = Some(window.id);
                             app.selected_window_title = Some(window.title);
+                            app.selected_display_indexes.clear();
                             app.refresh_foreground_profile();
                             app.pipeline_restart_needed = true;
                         }
@@ -1142,5 +1257,25 @@ mod tests {
             false,
         )
         .is_err());
+    }
+
+    #[test]
+    fn duplicate_display_indexes_are_rejected() {
+        assert_eq!(normalize_display_indexes(vec![0, 2]).unwrap(), vec![0, 2]);
+        assert!(normalize_display_indexes(vec![1, 1]).is_err());
+    }
+
+    #[test]
+    fn capture_source_label_includes_display_selection() {
+        assert_eq!(capture_source_label(CliSource::Screen, &[]), "screen");
+        assert_eq!(
+            capture_source_label(CliSource::Screen, &[2]),
+            "screen:display:2"
+        );
+        assert_eq!(
+            capture_source_label(CliSource::Screen, &[0, 1]),
+            "screen:displays:0,1"
+        );
+        assert_eq!(capture_source_label(CliSource::Pty, &[0]), "pty");
     }
 }


### PR DESCRIPTION
Closes #23

## Summary
- add a multi-display capture wrapper that composes selected displays into a side-by-side RGBA canvas
- add `aki list-displays` plus `--display` startup selection for one or more screen displays
- document layout, hot-plug behavior, and raw RGBA throughput for common display sets

## Validation
- `cargo fmt --all`
- `cargo test -p privacy-core multi_display -- --nocapture`
- `cargo test -p privacy-tui display -- --nocapture`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all`
- `cargo run -p privacy-tui -- --help`
- `cargo run -p privacy-tui -- --headless --source pty --display 0`
- `cargo run -p privacy-tui -- list-displays`
- `git diff --check`