### PR TITLE
[codex] add opt-in local LLM detector prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Because `Aki` works on pixels instead of browser DOM nodes, it can cover termina
 
 Screen pixels, OCR text, detections, config, and runtime logs stay on your machine. Local logs are written under `~/.config/ascii-privacy/logs/aki.log`; `Aki` does not upload them.
 
-Network activity is limited to actions you request: Homebrew or GitHub release downloads during install/update, the optional neural model download when the Neural transform is used without a cached model, optional Twitch chat integration if configured, and local OBS/MJPEG endpoints. These paths are not telemetry.
+Network activity is limited to actions you request: Homebrew or GitHub release downloads during install/update, the optional neural model download when the Neural transform is used without a cached model, optional Twitch chat integration if configured, the opt-in local LLM classifier endpoint if configured, and local OBS/MJPEG endpoints. These paths are not telemetry.
 
 Future uploaded counters or diagnostics are out of scope for v1 unless they are explicit opt-in before any data leaves the machine. The local `aki doctor` command prints setup checks without uploading anything.
 
@@ -146,6 +146,12 @@ $ aki --headless --source screen --display 0 --display 1 --record-output ./multi
 ```
 
 The behavior, hot-plug expectations, and performance costs are documented in [`docs/multi-display-capture.md`](./docs/multi-display-capture.md).
+
+### Opt-In Local Classifier
+
+The optional local LLM detector can ask a localhost Ollama model to classify ambiguous low-confidence OCR text as secret-shaped or safe. It is off by default, does not download models, and does not change the lightweight install path unless you enable it.
+
+Setup, privacy boundaries, and latency/accuracy tradeoffs are documented in [`docs/local-llm-detector.md`](./docs/local-llm-detector.md).
 
 ## Power-User / Developer Commands
 

--- a/docs/local-llm-detector.md
+++ b/docs/local-llm-detector.md
@@ -1,0 +1,56 @@
+# Opt-In Local LLM Detector
+
+This prototype classifies ambiguous low-confidence OCR text with a local model. It is disabled by default and does not change the default install footprint.
+
+The current provider path is Ollama on localhost. The default model name is `phi3:mini`, but any locally installed Ollama model can be configured.
+
+## Enable
+
+Install and start Ollama separately, then pull a small local model:
+
+```console
+$ ollama pull phi3:mini
+```
+
+Enable the classifier in `~/.config/ascii-privacy/config.toml`:
+
+```toml
+[detection]
+local_llm_enabled = true
+local_llm_provider = "ollama"
+local_llm_endpoint = "http://127.0.0.1:11434/api/generate"
+local_llm_model = "phi3:mini"
+local_llm_min_confidence = 20
+local_llm_max_regions_per_frame = 2
+local_llm_timeout_ms = 750
+```
+
+When disabled, `Aki` does not start Ollama, download a model, or call any model endpoint.
+
+## How It Runs
+
+The normal regex detector still handles OCR text at or above `detection.min_confidence`.
+
+When the local classifier is enabled, OCR keeps lower-confidence words down to `local_llm_min_confidence`. Only regions below the normal threshold are sent to the local classifier. If the model returns `SECRET`, the region is treated as a medium-severity `local-llm-secret-shape` match and goes through the normal region expansion and transform pipeline.
+
+The prompt asks for exactly `SECRET` or `SAFE`. Classifications that return anything else are ignored and logged.
+
+## Local-Only Boundary
+
+The prototype is local-only by configuration: it calls the configured endpoint, which should be a localhost Ollama server. Do not point `local_llm_endpoint` at a hosted model API unless you are intentionally changing that privacy boundary.
+
+Only OCR text snippets are sent to the local endpoint, not frame pixels.
+
+## Accuracy And Latency Tradeoffs
+
+This detector is useful for text that OCR can see but regex rules do not confidently match. It is not a replacement for rule packs.
+
+| Tradeoff | Impact |
+|----------|--------|
+| Recall | Can catch secret-shaped low-confidence text that regex scanning would otherwise skip. |
+| Precision | May mark random high-entropy strings as secrets, so matches use medium severity. |
+| Latency | Each local model call can add tens to hundreds of milliseconds, depending on model size and hardware. |
+| Throughput | `local_llm_max_regions_per_frame` caps work per frame; keep it low for live capture. |
+| Determinism | Small local models can still answer inconsistently, so non-`SECRET`/`SAFE` output is ignored. |
+
+Recommended defaults for live capture are a small model, a short timeout, and one or two low-confidence regions per frame. For offline redaction, higher limits are safer because latency is less visible.

--- a/privacy-core/src/config.rs
+++ b/privacy-core/src/config.rs
@@ -75,6 +75,20 @@ pub struct DetectionConfig {
     pub external_rules_format: String,
     /// Upper bound for imported external regex patterns.
     pub max_external_patterns: usize,
+    /// Enable the opt-in local LLM classifier for low-confidence OCR text.
+    pub local_llm_enabled: bool,
+    /// Local LLM provider. Currently supports "ollama".
+    pub local_llm_provider: String,
+    /// Local-only generation endpoint for the provider.
+    pub local_llm_endpoint: String,
+    /// Local model name to ask through the provider.
+    pub local_llm_model: String,
+    /// Lowest OCR confidence considered by the local classifier.
+    pub local_llm_min_confidence: u32,
+    /// Maximum low-confidence OCR regions classified per frame.
+    pub local_llm_max_regions_per_frame: usize,
+    /// Local classifier request timeout.
+    pub local_llm_timeout_ms: u64,
 }
 
 impl Default for DetectionConfig {
@@ -89,6 +103,13 @@ impl Default for DetectionConfig {
             external_rules_path: String::new(),
             external_rules_format: "gitleaks".into(),
             max_external_patterns: crate::detection::external_rules::DEFAULT_MAX_IMPORTED_PATTERNS,
+            local_llm_enabled: false,
+            local_llm_provider: "ollama".into(),
+            local_llm_endpoint: "http://127.0.0.1:11434/api/generate".into(),
+            local_llm_model: "phi3:mini".into(),
+            local_llm_min_confidence: 20,
+            local_llm_max_regions_per_frame: 2,
+            local_llm_timeout_ms: 750,
         }
     }
 }
@@ -260,5 +281,6 @@ mod tests {
         assert!((back.transform.intensity - cfg.transform.intensity).abs() < 1e-6);
         assert_eq!(back.output.http_port, cfg.output.http_port);
         assert!(back.foreground_profiles.enabled);
+        assert!(!back.detection.local_llm_enabled);
     }
 }

--- a/privacy-core/src/detection/local_llm.rs
+++ b/privacy-core/src/detection/local_llm.rs
@@ -1,0 +1,302 @@
+//! Opt-in local LLM classifier for low-confidence OCR regions.
+//!
+//! This detector is disabled by default. When enabled, it sends only OCR text
+//! snippets to a configured localhost model endpoint and converts "secret-shaped"
+//! classifications into normal sensitive matches.
+
+use anyhow::{anyhow, bail, Context, Result};
+use privacy_common::{
+    detection::{SensitiveMatch, Severity, TextRegion},
+    frame::Rect,
+};
+use serde::Deserialize;
+use serde_json::json;
+use std::time::Duration;
+
+use crate::{config::DetectionConfig, detection::whitelist::Whitelist};
+
+const PATTERN_NAME: &str = "local-llm-secret-shape";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalLlmConfig {
+    pub enabled: bool,
+    pub provider: String,
+    pub endpoint: String,
+    pub model: String,
+    pub min_confidence: u32,
+    pub max_regions_per_frame: usize,
+    pub timeout_ms: u64,
+}
+
+impl LocalLlmConfig {
+    pub fn from_detection_config(config: &DetectionConfig) -> Self {
+        Self {
+            enabled: config.local_llm_enabled,
+            provider: config.local_llm_provider.clone(),
+            endpoint: config.local_llm_endpoint.clone(),
+            model: config.local_llm_model.clone(),
+            min_confidence: config.local_llm_min_confidence.min(100),
+            max_regions_per_frame: config.local_llm_max_regions_per_frame,
+            timeout_ms: config.local_llm_timeout_ms.max(1),
+        }
+    }
+
+    pub fn ocr_min_confidence(&self, normal_min_confidence: f32) -> f32 {
+        if self.enabled {
+            (self.min_confidence as f32).min(normal_min_confidence)
+        } else {
+            normal_min_confidence
+        }
+    }
+
+    pub fn should_classify(&self, region: &TextRegion, normal_min_confidence: f32) -> bool {
+        self.enabled
+            && region.confidence >= self.min_confidence as f32
+            && region.confidence < normal_min_confidence
+            && !region.text.trim().is_empty()
+    }
+}
+
+pub struct LocalLlmDetector {
+    config: LocalLlmConfig,
+    agent: ureq::Agent,
+}
+
+impl LocalLlmDetector {
+    pub fn new(config: LocalLlmConfig) -> Self {
+        let agent = ureq::AgentBuilder::new()
+            .timeout(Duration::from_millis(config.timeout_ms))
+            .build();
+        Self { config, agent }
+    }
+
+    pub fn classify_regions(
+        &self,
+        regions: &[TextRegion],
+        whitelist: &Whitelist,
+        normal_min_confidence: f32,
+    ) -> Vec<SensitiveMatch> {
+        classify_low_confidence_regions(
+            &self.config,
+            regions,
+            whitelist,
+            normal_min_confidence,
+            |text| self.classify_text(text),
+        )
+    }
+
+    fn classify_text(&self, text: &str) -> Result<bool> {
+        match self.config.provider.as_str() {
+            "ollama" => self.classify_with_ollama(text),
+            other => bail!("unsupported local LLM provider: {other}"),
+        }
+    }
+
+    fn classify_with_ollama(&self, text: &str) -> Result<bool> {
+        let prompt = ollama_prompt(text);
+        let payload = json!({
+            "model": self.config.model,
+            "prompt": prompt,
+            "stream": false,
+            "options": {
+                "temperature": 0,
+                "num_predict": 4
+            }
+        });
+        let response = self
+            .agent
+            .post(&self.config.endpoint)
+            .set("Content-Type", "application/json")
+            .send_string(&serde_json::to_string(&payload).context("encoding Ollama request JSON")?)
+            .with_context(|| format!("calling local Ollama endpoint {}", self.config.endpoint))?;
+        let body = response
+            .into_string()
+            .context("reading local Ollama response body")?;
+        let body: OllamaGenerateResponse =
+            serde_json::from_str(&body).context("parsing local Ollama response JSON")?;
+        parse_secret_classification(&body.response)
+    }
+}
+
+pub fn classify_low_confidence_regions<F>(
+    config: &LocalLlmConfig,
+    regions: &[TextRegion],
+    whitelist: &Whitelist,
+    normal_min_confidence: f32,
+    mut classify_text: F,
+) -> Vec<SensitiveMatch>
+where
+    F: FnMut(&str) -> Result<bool>,
+{
+    if !config.enabled || config.max_regions_per_frame == 0 {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+    for region in regions
+        .iter()
+        .filter(|region| config.should_classify(region, normal_min_confidence))
+        .take(config.max_regions_per_frame)
+    {
+        if whitelist.is_safe(&region.text) {
+            continue;
+        }
+        match classify_text(&region.text) {
+            Ok(true) => matches.push(local_llm_match(region)),
+            Ok(false) => {}
+            Err(err) => log::warn!("local LLM classifier skipped region: {err}"),
+        }
+    }
+    matches
+}
+
+pub fn parse_secret_classification(response: &str) -> Result<bool> {
+    let normalized = response.trim().to_ascii_uppercase();
+    if normalized.starts_with("SECRET") {
+        return Ok(true);
+    }
+    if normalized.starts_with("SAFE") {
+        return Ok(false);
+    }
+    Err(anyhow!(
+        "local classifier returned neither SECRET nor SAFE: {response:?}"
+    ))
+}
+
+fn local_llm_match(region: &TextRegion) -> SensitiveMatch {
+    SensitiveMatch {
+        bounds: Rect {
+            x: region.bounds.x,
+            y: region.bounds.y,
+            width: region.bounds.width,
+            height: region.bounds.height,
+        },
+        pattern_name: PATTERN_NAME.to_string(),
+        severity: Severity::Medium,
+        snippet: make_snippet(&region.text),
+    }
+}
+
+fn make_snippet(text: &str) -> String {
+    let chars: Vec<char> = text.chars().collect();
+    if chars.len() <= 4 {
+        return "*".repeat(chars.len());
+    }
+    let prefix: String = chars[..4].iter().collect();
+    format!("{prefix}***")
+}
+
+fn ollama_prompt(text: &str) -> String {
+    format!(
+        "Classify this OCR text from a screen capture as SECRET or SAFE.\n\
+         SECRET means it is shaped like an API key, access token, password, private key, JWT, or credential value.\n\
+         SAFE means ordinary prose, labels, UI text, file paths, email addresses, or non-credential values.\n\
+         Return exactly SECRET or SAFE.\n\
+         OCR text: {text:?}"
+    )
+}
+
+#[derive(Debug, Deserialize)]
+struct OllamaGenerateResponse {
+    response: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use privacy_common::frame::Rect;
+
+    #[test]
+    fn default_config_is_disabled_and_does_not_lower_ocr_threshold() {
+        let detection = DetectionConfig::default();
+        let config = LocalLlmConfig::from_detection_config(&detection);
+
+        assert!(!config.enabled);
+        assert_eq!(config.ocr_min_confidence(40.0), 40.0);
+    }
+
+    #[test]
+    fn enabled_config_lowers_ocr_threshold_for_low_confidence_regions() {
+        let detection = DetectionConfig {
+            local_llm_enabled: true,
+            local_llm_min_confidence: 15,
+            ..DetectionConfig::default()
+        };
+        let config = LocalLlmConfig::from_detection_config(&detection);
+
+        assert_eq!(config.ocr_min_confidence(40.0), 15.0);
+    }
+
+    #[test]
+    fn parses_secret_or_safe_classifier_output() {
+        assert!(parse_secret_classification("SECRET").unwrap());
+        assert!(parse_secret_classification("secret\n").unwrap());
+        assert!(!parse_secret_classification("SAFE").unwrap());
+        assert!(parse_secret_classification("maybe").is_err());
+    }
+
+    #[test]
+    fn classifies_only_low_confidence_regions() {
+        let config = LocalLlmConfig {
+            enabled: true,
+            provider: "ollama".to_string(),
+            endpoint: "http://127.0.0.1:11434/api/generate".to_string(),
+            model: "phi3:mini".to_string(),
+            min_confidence: 20,
+            max_regions_per_frame: 4,
+            timeout_ms: 1,
+        };
+        let regions = vec![
+            text_region("AKIA_LOW_CONFIDENCE", 30.0, 0),
+            text_region("HIGH_CONFIDENCE", 80.0, 20),
+            text_region("TOO_LOW", 10.0, 40),
+        ];
+
+        let matches =
+            classify_low_confidence_regions(&config, &regions, &Whitelist::empty(), 60.0, |text| {
+                Ok(text.contains("AKIA"))
+            });
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].pattern_name, PATTERN_NAME);
+        assert_eq!(matches[0].bounds.y, 0);
+    }
+
+    #[test]
+    fn respects_max_regions_per_frame() {
+        let config = LocalLlmConfig {
+            enabled: true,
+            provider: "ollama".to_string(),
+            endpoint: "http://127.0.0.1:11434/api/generate".to_string(),
+            model: "phi3:mini".to_string(),
+            min_confidence: 20,
+            max_regions_per_frame: 1,
+            timeout_ms: 1,
+        };
+        let regions = vec![
+            text_region("FIRST", 30.0, 0),
+            text_region("SECOND", 30.0, 20),
+        ];
+
+        let matches =
+            classify_low_confidence_regions(&config, &regions, &Whitelist::empty(), 60.0, |_| {
+                Ok(true)
+            });
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].bounds.y, 0);
+    }
+
+    fn text_region(text: &str, confidence: f32, y: u32) -> TextRegion {
+        TextRegion {
+            text: text.to_string(),
+            bounds: Rect {
+                x: 0,
+                y,
+                width: 120,
+                height: 20,
+            },
+            confidence,
+        }
+    }
+}

--- a/privacy-core/src/detection/mod.rs
+++ b/privacy-core/src/detection/mod.rs
@@ -12,6 +12,7 @@ pub mod frame_diff;
 pub use frame_diff::FrameDiff;
 pub mod incremental;
 pub mod line_expand;
+pub mod local_llm;
 pub mod ocr;
 pub mod patterns;
 pub mod pii_patterns;

--- a/privacy-core/src/detection/whitelist.rs
+++ b/privacy-core/src/detection/whitelist.rs
@@ -33,6 +33,7 @@ struct WhitelistFile {
 }
 
 /// Compiled whitelist of safe-string patterns.
+#[derive(Clone)]
 pub struct Whitelist {
     regexes: Vec<Regex>,
 }

--- a/privacy-core/src/pipeline_runner.rs
+++ b/privacy-core/src/pipeline_runner.rs
@@ -10,6 +10,7 @@ use crate::{
         expand::expand_and_merge,
         incremental::{IncrementalOcr, GRID_COLS, GRID_ROWS},
         line_expand::expand_to_end_of_line,
+        local_llm::{LocalLlmConfig, LocalLlmDetector},
         ocr::OcrEngine,
         patterns::PatternRegistry,
         scanner::scan,
@@ -311,16 +312,18 @@ pub fn spawn_pipeline(
     let raw_rx = channels.raw_rx;
     let detection_tx = channels.detection_tx.clone();
     let state_d = Arc::clone(&state);
-    let min_conf = crate::config::AppConfig::load()
+    let detection_config = crate::config::AppConfig::load()
         .unwrap_or_default()
-        .detection
-        .min_confidence as f32;
+        .detection;
+    let min_conf = detection_config.min_confidence as f32;
+    let local_llm_config = LocalLlmConfig::from_detection_config(&detection_config);
+    let ocr_min_conf = local_llm_config.ocr_min_confidence(min_conf);
     let det_thread = thread::Builder::new()
         .name("aki-detect".into())
         .spawn(move || {
             log::info!("pipeline thread started: aki-detect");
             let ocr_engine =
-                match OcrEngine::new_with_confidence(ocr_data_path.as_deref(), min_conf) {
+                match OcrEngine::new_with_confidence(ocr_data_path.as_deref(), ocr_min_conf) {
                     Ok(o) => o,
                     Err(e) => {
                         log::error!("ocr engine init failed: {e}");
@@ -328,6 +331,9 @@ pub fn spawn_pipeline(
                     }
                 };
             let mut ocr = IncrementalOcr::new(ocr_engine, GRID_COLS, GRID_ROWS);
+            let local_llm_detector = local_llm_config
+                .enabled
+                .then(|| LocalLlmDetector::new(local_llm_config.clone()));
             let mut dedupe_cache: HashMap<DetectionDedupeKey, Instant> = HashMap::new();
             while state_d.running.load(Ordering::Relaxed) {
                 // apply adaptive grid if it changed
@@ -341,10 +347,23 @@ pub fn spawn_pipeline(
                         let t0 = Instant::now();
                         let regions = match ocr.extract(&frame) {
                             Ok(text_regions) => {
-                                let reg = state_d.registry.lock().unwrap();
-                                let wl = state_d.whitelist.lock().unwrap();
-                                let matches = scan(&text_regions, &reg, &wl);
-                                drop(wl);
+                                let high_confidence_regions = text_regions
+                                    .iter()
+                                    .filter(|region| region.confidence >= min_conf)
+                                    .cloned()
+                                    .collect::<Vec<_>>();
+                                let whitelist = state_d.whitelist.lock().unwrap().clone();
+                                let mut matches = {
+                                    let reg = state_d.registry.lock().unwrap();
+                                    scan(&high_confidence_regions, &reg, &whitelist)
+                                };
+                                if let Some(detector) = &local_llm_detector {
+                                    matches.extend(detector.classify_regions(
+                                        &text_regions,
+                                        &whitelist,
+                                        min_conf,
+                                    ));
+                                }
                                 let merged =
                                     expand_and_merge(matches, frame.width, frame.height, 0.10);
                                 let merged = expand_to_end_of_line(merged, frame.width);


### PR DESCRIPTION
Closes #24

## Summary
- add a disabled-by-default local LLM detector path for low-confidence OCR regions
- prototype Ollama localhost classification with strict `SECRET` / `SAFE` parsing and per-frame caps
- document setup, local-only boundaries, and accuracy/latency tradeoffs without README AI-positioning language

## Validation
- `cargo fmt --all`
- `cargo test -p privacy-core local_llm -- --nocapture`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all`
- `git diff --check`
- `rg -n "AI-powered|ai-powered|AI powered|ai powered" README.md docs/local-llm-detector.md` returned no matches
- `rg -n "\bAI\b|Artificial|powered" README.md` returned no matches