### PR TITLE
[codex] add Shortcuts automation actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ cargo build -p privacy-tui
 $ AKI_BINARY="$PWD/target/debug/aki" swift run --package-path macos/AkiMenuBar
 ```
 
-The menu-bar shell can start and stop the headless redaction pipeline, pause or resume it, switch transforms, choose the capture/output mode used on restart, show redaction/FPS/CPU stats, and open the TUI in Terminal. The v1 sidecar protocol is documented in [`docs/sidecar-protocol.md`](./docs/sidecar-protocol.md).
+The menu-bar shell can start and stop the headless redaction pipeline, pause or resume it, switch transforms, choose the capture/output mode used on restart, show redaction/FPS/CPU stats, and open the TUI in Terminal. The v1 sidecar protocol is documented in [`docs/sidecar-protocol.md`](./docs/sidecar-protocol.md), and Shortcuts/AppleScript automation is documented in [`docs/apple-shortcuts.md`](./docs/apple-shortcuts.md).
 
 macOS DMG release packaging is documented in [`docs/macos-release.md`](./docs/macos-release.md), and the cask path is documented in [`docs/homebrew-cask.md`](./docs/homebrew-cask.md). The Show HN launch gate is tracked in [`docs/show-hn-readiness.md`](./docs/show-hn-readiness.md); do not advertise a Show HN launch until that checklist is complete.
 

--- a/docs/apple-shortcuts.md
+++ b/docs/apple-shortcuts.md
@@ -1,0 +1,59 @@
+# AppleScript And Shortcuts Automation
+
+The macOS menu-bar app exposes a small Shortcuts surface through App Intents. The menu-bar app remains the primary UI; automation routes through the same `AkiMenuController` that backs the menu extra.
+
+## Shortcuts Actions
+
+The first exposed action is `Control Aki`.
+
+Supported values:
+
+- `Start`
+- `Stop`
+- `Pause or Resume`
+- `Open TUI`
+
+The app also donates prebuilt App Shortcuts:
+
+- `Start Aki`
+- `Stop Aki`
+- `Pause or Resume`
+- `Open TUI`
+
+These actions control the existing Rust sidecar process. They do not introduce a second automation-only runtime.
+
+## AppleScript Entry
+
+AppleScript users can invoke the Shortcuts action through the macOS `shortcuts` command:
+
+```applescript
+do shell script "shortcuts run 'Start Aki'"
+do shell script "shortcuts run 'Pause or Resume'"
+do shell script "shortcuts run 'Stop Aki'"
+```
+
+Direct AppleScript commands are intentionally not a separate control surface yet. Keeping AppleScript routed through Shortcuts avoids another protocol while preserving a scriptable path.
+
+## Entitlements And Permissions
+
+App Intents and App Shortcuts do not require an extra entitlement by themselves when they are compiled into the app target.
+
+For the current menu-bar shell:
+
+| Capability | Required for | Notes |
+|------------|--------------|-------|
+| Screen Recording permission | ScreenCaptureKit sidecar capture | User grants this in System Settings for the shipped app or sidecar binary. |
+| Apple Events automation | `Open TUI` when sandboxed | The app launches Terminal through AppleScript. A sandboxed distribution needs `com.apple.security.automation.apple-events` and `NSAppleEventsUsageDescription`. |
+| Network client | Local WebSocket control when sandboxed | The menu-bar app talks to `ws://127.0.0.1:9877`; sandboxed builds need outbound network client entitlement. |
+
+The current Developer ID DMG flow is not sandboxed, so the entitlement list is a packaging guide for future sandboxed/App Store-style builds rather than a new requirement for source builds.
+
+## Build Check
+
+Run:
+
+```console
+$ swift build --package-path macos/AkiMenuBar
+```
+
+The Shortcuts metadata is compiled into the `AkiMenuBar` target. After launching the built app bundle, macOS can discover the shortcuts through the Shortcuts app.

--- a/macos/AkiMenuBar/Sources/AkiMenuBar/App/AkiMenuBarApp.swift
+++ b/macos/AkiMenuBar/Sources/AkiMenuBar/App/AkiMenuBarApp.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 @main
 struct AkiMenuBarApp: App {
-    @StateObject private var controller = AkiMenuController()
+    @StateObject private var controller = AkiMenuController.shared
 
     var body: some Scene {
         MenuBarExtra {

--- a/macos/AkiMenuBar/Sources/AkiMenuBar/Intents/AkiAutomationIntents.swift
+++ b/macos/AkiMenuBar/Sources/AkiMenuBar/Intents/AkiAutomationIntents.swift
@@ -1,0 +1,120 @@
+import AppIntents
+import Foundation
+
+enum AkiAutomationAction: String, AppEnum {
+    case start
+    case stop
+    case pauseOrResume
+    case openTUI
+
+    static var typeDisplayName: LocalizedStringResource { "Aki Action" }
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Aki Action"
+
+    static var caseDisplayRepresentations: [Self: DisplayRepresentation] {
+        [
+            .start: "Start",
+            .stop: "Stop",
+            .pauseOrResume: "Pause or Resume",
+            .openTUI: "Open TUI"
+        ]
+    }
+}
+
+struct ControlAkiIntent: AppIntent {
+    static let title: LocalizedStringResource = "Control Aki"
+    static let description = IntentDescription("Start, stop, pause, resume, or open the Aki TUI.")
+    static let openAppWhenRun = true
+
+    @Parameter(title: "Action")
+    var action: AkiAutomationAction
+
+    init() {
+        self.action = .start
+    }
+
+    init(action: AkiAutomationAction) {
+        self.action = action
+    }
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let message = await MainActor.run {
+            AkiAutomationBridge.perform(action)
+        }
+        return .result(dialog: "\(message)")
+    }
+}
+
+struct AkiAppShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: ControlAkiIntent(action: .start),
+            phrases: [
+                "Start \(.applicationName)",
+                "Start privacy filter with \(.applicationName)"
+            ],
+            shortTitle: "Start Aki",
+            systemImageName: "play.fill"
+        )
+
+        AppShortcut(
+            intent: ControlAkiIntent(action: .stop),
+            phrases: [
+                "Stop \(.applicationName)",
+                "Stop privacy filter with \(.applicationName)"
+            ],
+            shortTitle: "Stop Aki",
+            systemImageName: "stop.fill"
+        )
+
+        AppShortcut(
+            intent: ControlAkiIntent(action: .pauseOrResume),
+            phrases: [
+                "Pause \(.applicationName)",
+                "Resume \(.applicationName)"
+            ],
+            shortTitle: "Pause or Resume",
+            systemImageName: "pause.circle"
+        )
+
+        AppShortcut(
+            intent: ControlAkiIntent(action: .openTUI),
+            phrases: [
+                "Open TUI in \(.applicationName)",
+                "Open terminal UI in \(.applicationName)"
+            ],
+            shortTitle: "Open TUI",
+            systemImageName: "terminal"
+        )
+    }
+}
+
+@MainActor
+enum AkiAutomationBridge {
+    static func perform(_ action: AkiAutomationAction) -> String {
+        let controller = AkiMenuController.shared
+        switch action {
+        case .start:
+            if controller.isRunning {
+                return "Aki is already running."
+            }
+            controller.start()
+            return "Started Aki."
+        case .stop:
+            if !controller.isRunning {
+                return "Aki is already stopped."
+            }
+            controller.stop()
+            return "Stopped Aki."
+        case .pauseOrResume:
+            if !controller.isRunning {
+                controller.start()
+                return "Started Aki."
+            }
+            controller.togglePause()
+            return controller.isPaused ? "Resuming Aki." : "Pausing Aki."
+        case .openTUI:
+            controller.openTUI()
+            return "Opened Aki TUI."
+        }
+    }
+}

--- a/macos/AkiMenuBar/Sources/AkiMenuBar/Stores/AkiMenuController.swift
+++ b/macos/AkiMenuBar/Sources/AkiMenuBar/Stores/AkiMenuController.swift
@@ -2,6 +2,8 @@ import Foundation
 
 @MainActor
 final class AkiMenuController: ObservableObject {
+    static let shared = AkiMenuController()
+
     @Published var source: CaptureSource = .screen
     @Published var transform: TransformChoice = .ascii
     @Published var output: OutputChoice = .auto


### PR DESCRIPTION
Closes #25

## Summary
- add a `Control Aki` App Intent with Start, Stop, Pause or Resume, and Open TUI actions
- register prebuilt App Shortcuts that route through the shared menu-bar controller
- document Shortcuts usage, AppleScript invocation through `shortcuts run`, and entitlement/permission requirements

## Validation
- `swift build --package-path macos/AkiMenuBar`
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all`
- `git diff --check`

## References
- Apple App Intents docs: https://developer.apple.com/documentation/AppIntents/AppIntent
- Apple AppShortcutsProvider docs: https://developer.apple.com/documentation/appintents/appshortcutsprovider