### PR TITLE
[codex] add benchmarks and redaction fixture corpus

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,88 @@
+# Benchmarks
+
+Benchmarks should be reproducible and tied to hardware context. The numbers below are a starting baseline, not a promise that every screen, font, display, or OCR workload will behave the same.
+
+## Hardware Context
+
+Measured on 2026-06-03:
+
+| Field | Value |
+|-------|-------|
+| CPU | Apple M3 |
+| Memory | 16 GiB |
+| OS | macOS 26.2 (25C56) |
+| Rust | rustc 1.93.0 / cargo 1.93.0 |
+
+## Commands
+
+Run the held-out fixture recall check:
+
+```console
+$ cargo test -p privacy-core synthetic_fixture_corpus_recall_is_tracked -- --nocapture
+```
+
+Run the synthetic resolution benchmark:
+
+```console
+$ /usr/bin/time -l cargo test -p privacy-core synthetic_resolution_benchmark -- --ignored --nocapture
+```
+
+For live capture FPS and dropped-frame behavior, run a 60-second headless session and inspect the generated session log:
+
+```console
+$ cargo run -p privacy-tui -- --headless --source screen --display 0 --output mjpeg
+$ tail -n 20 ~/.config/ascii-privacy/sessions/headless_*.log
+```
+
+## Synthetic Resolution Baseline
+
+Command:
+
+```console
+$ /usr/bin/time -l cargo test -p privacy-core synthetic_resolution_benchmark -- --ignored --nocapture
+```
+
+This benchmark generates synthetic RGBA frames, runs regex scan, region expansion, and a pixelate transform. It does **not** run Tesseract OCR or ScreenCaptureKit capture.
+
+| Resolution | Frames | FPS | Mean frame latency | Recall |
+|------------|--------|-----|--------------------|--------|
+| 1920x1080 | 120 | 260.8 | 3.83 ms | 1.00 |
+| 2560x1440 | 90 | 146.0 | 6.85 ms | 1.00 |
+| 3840x2160 | 45 | 68.1 | 14.69 ms | 1.00 |
+
+Peak RSS from `/usr/bin/time -l`: `189,267,968` bytes, about `180.5 MiB`.
+
+## Fixture Corpus
+
+Corpus path:
+
+```console
+privacy-core/fixtures/redaction_corpus/synthetic-corpus.toml
+```
+
+The corpus is synthetic and held out from the pattern definitions. Fixture values use `AKI_FIXTURE` and `DO_NOT_USE` markers rather than real credentials.
+
+| Frame | Resolution | Expected detections | Detected | Recall |
+|-------|------------|---------------------|----------|--------|
+| `terminal_1080p_env_and_secret` | 1920x1080 | 2 | 2 | 1.00 |
+| `editor_1440p_pii_and_password` | 2560x1440 | 2 | 2 | 1.00 |
+| `dashboard_4k_network_and_key_header` | 3840x2160 | 2 | 2 | 1.00 |
+
+Overall fixture recall: `6 / 6 = 1.00`.
+
+Approximate OCR cell hit-rate for the fixture corpus: `17 / 144 = 11.8%`, using the default 8x6 grid across three frames. This is synthetic text-region occupancy, not a live Tesseract dirty-cell measurement.
+
+## Limits
+
+The synthetic benchmark is useful for tracking redaction transform cost and fixture recall, but it is not full end-to-end capture performance.
+
+Live performance is lower because the real pipeline also pays for:
+
+- ScreenCaptureKit frame delivery,
+- TIFF conversion before OCR,
+- Tesseract OCR latency,
+- incremental OCR grid scheduling,
+- preview cloning and terminal rendering,
+- output sink encoding or virtual-camera writes.
+
+OCR is the least stable part of the pipeline. Tiny text, low contrast, animation, display scaling, and first-frame appearance can reduce recall or add latency. Treat these numbers as a regression baseline, not as proof that every secret on a real screen is caught.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ The menu-bar shell can start and stop the headless redaction pipeline, pause or 
 
 macOS DMG release packaging is documented in [`docs/macos-release.md`](./docs/macos-release.md), and the cask path is documented in [`docs/homebrew-cask.md`](./docs/homebrew-cask.md). The Show HN launch gate is tracked in [`docs/show-hn-readiness.md`](./docs/show-hn-readiness.md); do not advertise a Show HN launch until that checklist is complete.
 
+Performance baselines and the synthetic redaction fixture corpus are tracked in [`BENCHMARKS.md`](./BENCHMARKS.md).
+
 ## Quick Commands
 
 ```console

--- a/privacy-core/fixtures/redaction_corpus/synthetic-corpus.toml
+++ b/privacy-core/fixtures/redaction_corpus/synthetic-corpus.toml
@@ -1,0 +1,69 @@
+# Synthetic held-out redaction corpus.
+#
+# Values are deliberately fake and use AKI_FIXTURE / DO_NOT_USE markers.
+
+grid_cols = 8
+grid_rows = 6
+
+[[frames]]
+id = "terminal_1080p_env_and_secret"
+resolution = [1920, 1080]
+description = "Terminal-like frame with an environment assignment and secret keyword."
+
+[[frames.regions]]
+text = "AKI_FIXTURE_SECRET=DO_NOT_USE_TERMINAL_VALUE_001"
+bounds = [96, 120, 760, 36]
+confidence = 96.0
+expected_patterns = ["env_var_assignment", "secret_keyword"]
+
+[[frames.regions]]
+text = "cargo run --example demo"
+bounds = [96, 180, 360, 36]
+confidence = 94.0
+expected_patterns = []
+
+[[frames]]
+id = "editor_1440p_pii_and_password"
+resolution = [2560, 1440]
+description = "Editor-like frame with PII and a password-shaped assignment."
+
+[[frames.regions]]
+text = "contact: demo.user@example.invalid"
+bounds = [160, 220, 540, 42]
+confidence = 91.0
+expected_patterns = ["email"]
+
+[[frames.regions]]
+text = "password=DO_NOT_USE_EDITOR_PASSWORD_002"
+bounds = [160, 290, 700, 42]
+confidence = 93.0
+expected_patterns = ["secret_keyword"]
+
+[[frames.regions]]
+text = "let status = \"ready\";"
+bounds = [160, 360, 360, 42]
+confidence = 95.0
+expected_patterns = []
+
+[[frames]]
+id = "dashboard_4k_network_and_key_header"
+resolution = [3840, 2160]
+description = "Dashboard-like frame with IP PII and a private-key header."
+
+[[frames.regions]]
+text = "server: 192.168.1.100"
+bounds = [240, 320, 520, 54]
+confidence = 89.0
+expected_patterns = ["ipv4"]
+
+[[frames.regions]]
+text = "-----BEGIN OPENSSH PRIVATE KEY-----"
+bounds = [240, 410, 820, 54]
+confidence = 88.0
+expected_patterns = ["ssh_private_key"]
+
+[[frames.regions]]
+text = "mode: fixture-only"
+bounds = [240, 500, 360, 54]
+confidence = 92.0
+expected_patterns = []

--- a/privacy-core/src/benchmarks.rs
+++ b/privacy-core/src/benchmarks.rs
@@ -1,0 +1,129 @@
+use crate::{
+    detection::{
+        expand::expand_and_merge, line_expand::expand_to_end_of_line, registry::runtime_registry,
+        scanner::scan, whitelist::Whitelist,
+    },
+    transform::registry::apply_transform,
+};
+use privacy_common::{
+    detection::{DetectedRegions, TextRegion},
+    frame::{RawFrame, Rect},
+    transform::TransformMode,
+};
+use std::time::Instant;
+
+#[ignore = "synthetic benchmark; run manually with --ignored --nocapture"]
+#[test]
+fn synthetic_resolution_benchmark() {
+    let cases = [
+        BenchmarkCase {
+            label: "1080p",
+            width: 1920,
+            height: 1080,
+            frames: 120,
+        },
+        BenchmarkCase {
+            label: "1440p",
+            width: 2560,
+            height: 1440,
+            frames: 90,
+        },
+        BenchmarkCase {
+            label: "4k",
+            width: 3840,
+            height: 2160,
+            frames: 45,
+        },
+    ];
+    let registry = runtime_registry(&crate::config::AppConfig::default());
+    let whitelist = Whitelist::empty();
+
+    println!("synthetic redaction benchmark: scan + expand + pixelate transform");
+    println!("label,resolution,frames,fps,mean_latency_ms,recall");
+
+    for case in cases {
+        let frame = fixture_frame(case.width, case.height);
+        let regions = fixture_regions(case.width, case.height);
+        let expected_patterns = 2usize;
+        let started = Instant::now();
+        let mut detected_total = 0usize;
+
+        for _ in 0..case.frames {
+            let matches = scan(&regions, &registry, &whitelist);
+            let merged = expand_to_end_of_line(
+                expand_and_merge(matches.clone(), frame.width, frame.height, 0.10),
+                frame.width,
+            );
+            let transformed = apply_transform(
+                &frame,
+                &DetectedRegions { matches: merged },
+                TransformMode::Pixelate,
+                1.0,
+            )
+            .expect("synthetic transform should succeed");
+            assert_eq!(transformed.width, frame.width);
+            assert_eq!(transformed.height, frame.height);
+            detected_total += matches.len().min(expected_patterns);
+        }
+
+        let elapsed = started.elapsed().as_secs_f64();
+        let fps = case.frames as f64 / elapsed.max(f64::EPSILON);
+        let mean_latency_ms = elapsed * 1000.0 / case.frames as f64;
+        let recall = detected_total as f64 / (expected_patterns * case.frames as usize) as f64;
+
+        println!(
+            "{},{}x{},{},{:.1},{:.2},{:.2}",
+            case.label, case.width, case.height, case.frames, fps, mean_latency_ms, recall
+        );
+    }
+}
+
+struct BenchmarkCase {
+    label: &'static str,
+    width: u32,
+    height: u32,
+    frames: u32,
+}
+
+fn fixture_frame(width: u32, height: u32) -> RawFrame {
+    let mut pixels = Vec::with_capacity((width * height * 4) as usize);
+    for y in 0..height {
+        for x in 0..width {
+            pixels.push(((x / 8) % 255) as u8);
+            pixels.push(((y / 8) % 255) as u8);
+            pixels.push((((x + y) / 16) % 255) as u8);
+            pixels.push(255);
+        }
+    }
+    RawFrame {
+        pixels,
+        width,
+        height,
+        timestamp: chrono::Utc::now(),
+    }
+}
+
+fn fixture_regions(width: u32, height: u32) -> Vec<TextRegion> {
+    vec![
+        TextRegion {
+            text: "AKI_FIXTURE_SECRET=DO_NOT_USE_BENCHMARK_VALUE".to_string(),
+            bounds: Rect {
+                x: width / 16,
+                y: height / 10,
+                width: width / 3,
+                height: (height / 32).max(24),
+            },
+            confidence: 96.0,
+        },
+        TextRegion {
+            text: "contact: benchmark.user@example.invalid".to_string(),
+            bounds: Rect {
+                x: width / 16,
+                y: height / 5,
+                width: width / 4,
+                height: (height / 32).max(24),
+            },
+            confidence: 92.0,
+        },
+    ]
+}

--- a/privacy-core/src/detection/scanner.rs
+++ b/privacy-core/src/detection/scanner.rs
@@ -57,8 +57,9 @@ fn make_snippet(text: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::detection::default_patterns::default_registry;
+    use crate::{config::AppConfig, detection::registry::runtime_registry};
     use privacy_common::frame::Rect;
+    use serde::Deserialize;
 
     fn make_region(text: &str) -> TextRegion {
         TextRegion {
@@ -75,7 +76,7 @@ mod tests {
 
     #[test]
     fn detects_env_var() {
-        let reg = default_registry();
+        let reg = runtime_registry(&AppConfig::default());
         let regions = vec![make_region("SECRET_KEY=abc123def456")];
         let matches = scan(
             &regions,
@@ -89,5 +90,72 @@ mod tests {
     fn snippet_format() {
         assert_eq!(make_snippet("hello_world"), "hell***");
         assert_eq!(make_snippet("abc"), "***");
+    }
+
+    #[test]
+    fn synthetic_fixture_corpus_recall_is_tracked() {
+        let corpus: FixtureCorpus = toml::from_str(include_str!(
+            "../../fixtures/redaction_corpus/synthetic-corpus.toml"
+        ))
+        .unwrap();
+        let registry = runtime_registry(&AppConfig::default());
+        let whitelist = crate::detection::whitelist::Whitelist::empty();
+        let mut expected = 0usize;
+        let mut detected = 0usize;
+
+        for frame in &corpus.frames {
+            let regions = frame
+                .regions
+                .iter()
+                .map(|region| TextRegion {
+                    text: region.text.clone(),
+                    bounds: Rect {
+                        x: region.bounds[0],
+                        y: region.bounds[1],
+                        width: region.bounds[2],
+                        height: region.bounds[3],
+                    },
+                    confidence: region.confidence,
+                })
+                .collect::<Vec<_>>();
+            let matches = scan(&regions, &registry, &whitelist);
+
+            for region in &frame.regions {
+                for pattern in &region.expected_patterns {
+                    expected += 1;
+                    if matches
+                        .iter()
+                        .any(|candidate| candidate.pattern_name == *pattern)
+                    {
+                        detected += 1;
+                    } else {
+                        panic!("{} missed expected pattern {pattern}", frame.id);
+                    }
+                }
+            }
+        }
+
+        assert_eq!(expected, 6);
+        assert_eq!(detected, expected);
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct FixtureCorpus {
+        frames: Vec<FixtureFrame>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct FixtureFrame {
+        id: String,
+        regions: Vec<FixtureRegion>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct FixtureRegion {
+        text: String,
+        bounds: [u32; 4],
+        confidence: f32,
+        #[serde(default)]
+        expected_patterns: Vec<String>,
     }
 }

--- a/privacy-core/src/lib.rs
+++ b/privacy-core/src/lib.rs
@@ -6,3 +6,6 @@ pub mod pipeline;
 pub mod pipeline_runner;
 pub mod time_machine;
 pub mod transform;
+
+#[cfg(test)]
+mod benchmarks;


### PR DESCRIPTION
Closes #26

## Summary
- add `BENCHMARKS.md` with hardware context, reproducible commands, synthetic FPS/latency/RSS numbers, and OCR limitations
- add a held-out synthetic redaction corpus covering 1080p, 1440p, and 4K fixture cases
- add a non-ignored corpus recall test plus an ignored synthetic resolution benchmark harness

## Baseline numbers
- 1080p: 260.8 FPS, 3.83 ms mean synthetic frame latency
- 1440p: 146.0 FPS, 6.85 ms mean synthetic frame latency
- 4K: 68.1 FPS, 14.69 ms mean synthetic frame latency
- fixture recall: 6 / 6 = 1.00
- peak RSS under `/usr/bin/time -l`: 189,267,968 bytes

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all`
- `cargo test -p privacy-core synthetic_fixture_corpus_recall_is_tracked -- --nocapture`
- `/usr/bin/time -l cargo test -p privacy-core synthetic_resolution_benchmark -- --ignored --nocapture`
- `git diff --check`