### PR TITLE
[codex] add public roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ The engineering architecture is documented in [`ARCHITECTURE.md`](./ARCHITECTURE
 
 Performance baselines and the synthetic redaction fixture corpus are tracked in [`BENCHMARKS.md`](./BENCHMARKS.md).
 
+The public roadmap is tracked in [`docs/roadmap.md`](./docs/roadmap.md).
+
 ## Quick Commands
 
 ```console

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,9 +6,9 @@ This roadmap is a public direction board for contributors and evaluators. It is 
 
 | Column | Meaning |
 |--------|---------|
-| Now | Current contributor-facing polish and trust work. These are the best issues to check first. |
-| Next | Useful follow-up work once the contributor surface is cleaner. |
-| Later | Brand, launch, and stretch ideas that should not block core quality. |
+| Now | Current v1 contributor-facing polish and trust work. These are the best issues to check first. |
+| Next | Phase-2 distribution and launch preparation once the contributor surface is cleaner. |
+| Later | Brand, launch, and stretch ideas that should not imply commitments or block core quality. |
 
 ## Now
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,42 @@
+# Roadmap
+
+This roadmap is a public direction board for contributors and evaluators. It is not a commitment schedule, and items can move as the project learns from users.
+
+## Status Columns
+
+| Column | Meaning |
+|--------|---------|
+| Now | Current contributor-facing polish and trust work. These are the best issues to check first. |
+| Next | Useful follow-up work once the contributor surface is cleaner. |
+| Later | Brand, launch, and stretch ideas that should not block core quality. |
+
+## Now
+
+| Issue | Why now |
+|-------|---------|
+| [#29 Add CONTRIBUTING.md and curated good first issues](https://github.com/gongahkia/aki/issues/29) | Converts readers into contributors and gives newcomers a safe entry point. |
+| [#30 Strengthen CI badge and validation workflow](https://github.com/gongahkia/aki/issues/30) | Makes the README badge reflect meaningful checks, not just repository activity. |
+| [#31 Add SECURITY.md reporting path](https://github.com/gongahkia/aki/issues/31) | Establishes a responsible disclosure path for a privacy/security-adjacent tool. |
+
+## Next
+
+| Issue | Why next |
+|-------|----------|
+| [#32 Tag releases with changelogs](https://github.com/gongahkia/aki/issues/32) | Makes release history visible and reduces the appearance of an unshipped project. |
+| [#33 Draft companion engineering blog post](https://github.com/gongahkia/aki/issues/33) | Explains the technical hook after the architecture and benchmark docs exist. |
+| [#34 Add cargo install and Nix install paths](https://github.com/gongahkia/aki/issues/34) | Adds discovery and install paths for Rust and Nix users. |
+| [#35 Prepare platform-specific launch copy](https://github.com/gongahkia/aki/issues/35) | Keeps future launch work coordinated without rushing a Show HN post. |
+
+## Later
+
+| Issue | Why later |
+|-------|-----------|
+| [#36 Build one-page landing site](https://github.com/gongahkia/aki/issues/36) | Useful for SEO and non-GitHub readers after install and contributor basics are stronger. |
+| [#37 Create logo, favicon, and social card assets](https://github.com/gongahkia/aki/issues/37) | Brand polish is helpful, but it should not outrank trust and install work. |
+| [#38 Produce 60-second narrated demo video](https://github.com/gongahkia/aki/issues/38) | Valuable launch artifact once the product story is stable. |
+| [#39 Add hidden stress test and sticker command](https://github.com/gongahkia/aki/issues/39) | Fun polish and demos belong after the practical launch surface. |
+| [#40 Document anti-goals and stretch backlog](https://github.com/gongahkia/aki/issues/40) | Keeps scope honest and collects ideas that should not sneak into v1/v2 by accident. |
+
+## Maintenance
+
+When an issue closes, remove it from this page or move the remaining related work into a new issue. If a new issue is urgent, add it to `Now` with a short reason instead of relying on issue number order.


### PR DESCRIPTION
Closes #28

## Summary
- add a public Now/Next/Later roadmap covering the current v1, phase-2, and stretch backlog issues
- link the roadmap from the README contributor/project docs section

## Validation
- git diff --check