### PR TITLE
[codex] add release changelog workflow

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -19,6 +19,9 @@ jobs:
   release-macos:
     runs-on: macos-latest
     environment: release
+    env:
+      VERSION: ${{ inputs.version }}
+      TAG: ${{ inputs.tag }}
     steps:
       - uses: actions/checkout@v4
 
@@ -26,6 +29,9 @@ jobs:
 
       - name: Install native dependencies
         run: brew install tesseract libarchive
+
+      - name: Validate release metadata
+        run: scripts/check_release_metadata.sh --version "$VERSION" --tag "$TAG"
 
       - name: Import Developer ID certificate
         env:
@@ -52,7 +58,7 @@ jobs:
 
       - name: Build signed notarized DMG
         env:
-          AKI_VERSION: ${{ inputs.version }}
+          AKI_VERSION: ${{ env.VERSION }}
           AKI_SIGN_IDENTITY: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION_IDENTITY }}
           AKI_NOTARY_APPLE_ID: ${{ secrets.AKI_NOTARY_APPLE_ID }}
           AKI_NOTARY_TEAM_ID: ${{ secrets.AKI_NOTARY_TEAM_ID }}
@@ -62,17 +68,22 @@ jobs:
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ inputs.tag }}
-          VERSION: ${{ inputs.version }}
         run: |
           DMG="dist/macos/Aki-${VERSION}-macos.dmg"
           SHA="${DMG}.sha256"
+          NOTES="$(mktemp)"
+          scripts/release_notes_from_changelog.sh --version "$VERSION" --tag "$TAG" > "$NOTES"
+
           if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" \
+              --title "Aki ${VERSION}" \
+              --notes-file "$NOTES"
             gh release upload "$TAG" "$DMG" "$SHA" --clobber
           else
             gh release create "$TAG" "$DMG" "$SHA" \
               --title "Aki ${VERSION}" \
-              --generate-notes
+              --target "$GITHUB_SHA" \
+              --notes-file "$NOTES"
           fi
 
       - name: Delete signing keychain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable release changes are tracked here. Release sections use the Git tag as the heading so the macOS release workflow can publish the matching section as GitHub Release notes.
+
+## v0.1.0 - Next release
+
+Tag: `v0.1.0`
+Version: `0.1.0`
+
+Install artifacts, published by the protected macOS release workflow:
+
+- [Aki-0.1.0-macos.dmg](https://github.com/gongahkia/aki/releases/download/v0.1.0/Aki-0.1.0-macos.dmg)
+- [Aki-0.1.0-macos.dmg.sha256](https://github.com/gongahkia/aki/releases/download/v0.1.0/Aki-0.1.0-macos.dmg.sha256)
+
+### Added
+
+- Local-first screen privacy filter with OCR and pattern-based secret/PII detection.
+- TUI and headless CLI modes with virtual camera, MJPEG, OBS prototype, and direct MP4 recording outputs.
+- Offline video redaction through `aki redact`.
+- Menu-bar sidecar shell with AppleScript and Shortcuts automation intents.
+- Local-only `aki doctor`, fake-secret demo, redaction log, foreground-app profiles, external rule-pack import, and opt-in local LLM detector.
+- Architecture, benchmark, release, cask, contributing, security, and roadmap documentation.
+
+### Release Notes
+
+- The public release tag is `v0.1.0`.
+- The README version badge, workspace version, cask version, release tag, and DMG filename must all stay on `0.1.0` for this release.
+- Do not advertise the Homebrew cask as install-ready until the signed and notarized DMG plus checksum are attached to the GitHub Release.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ The engineering architecture is documented in [`ARCHITECTURE.md`](./ARCHITECTURE
 
 Performance baselines and the synthetic redaction fixture corpus are tracked in [`BENCHMARKS.md`](./BENCHMARKS.md).
 
+Release history and the next release notes are tracked in [`CHANGELOG.md`](./CHANGELOG.md).
+
 The public roadmap is tracked in [`docs/roadmap.md`](./docs/roadmap.md).
 
 Contributor setup and pull request expectations are documented in [`CONTRIBUTING.md`](./CONTRIBUTING.md).

--- a/docs/macos-release.md
+++ b/docs/macos-release.md
@@ -55,6 +55,22 @@ The script writes:
 - `dist/macos/Aki-<version>-macos.dmg`
 - `dist/macos/Aki-<version>-macos.dmg.sha256`
 
+## Tags And Changelog
+
+Use SemVer tags with a leading `v`, for example `v0.1.0` for version `0.1.0`.
+
+Before publishing a release:
+
+- `Cargo.toml` workspace version, README badge, `Casks/aki.rb` version, release tag, and DMG filename must refer to the same version.
+- `CHANGELOG.md` must contain a matching `## v<version>` section.
+- The changelog section must link the DMG and `.sha256` install artifacts that the GitHub Release will publish.
+
+Validate this locally before dispatching the workflow:
+
+```console
+$ scripts/check_release_metadata.sh --version 0.1.0 --tag v0.1.0
+```
+
 ## What The Script Verifies
 
 The release script:
@@ -79,7 +95,7 @@ The manual workflow at `.github/workflows/release-macos.yml` packages and upload
 - `AKI_NOTARY_TEAM_ID`
 - `AKI_NOTARY_PASSWORD`
 
-The workflow creates or updates the requested GitHub Release and uploads the DMG plus SHA-256 file, so the release notes link directly to the artifact.
+The workflow creates or updates the requested GitHub Release, publishes release notes from the matching `CHANGELOG.md` section, and uploads the DMG plus SHA-256 file. The generated release notes include direct links to both install artifacts.
 
 Contributors without release credentials should use `scripts/release_macos_dmg.sh --unsigned` instead of the signed workflow.
 

--- a/docs/show-hn-readiness.md
+++ b/docs/show-hn-readiness.md
@@ -30,6 +30,7 @@ Run these before marking the gate complete:
 
 ```console
 $ rg -n "Version [0-9]|version-[0-9]|version \"|version = \"" README.md Cargo.toml Casks/aki.rb
+$ scripts/check_release_metadata.sh --version 0.1.0 --tag v0.1.0
 $ test -f asset/demo/hero-ascii-redaction.gif
 $ gh release view v0.1.0 --json tagName,name,assets
 $ xcrun stapler validate /Volumes/Aki/Aki.app

--- a/scripts/check_release_metadata.sh
+++ b/scripts/check_release_metadata.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/check_release_metadata.sh --version VERSION --tag TAG
+
+Verifies release metadata that must agree before publishing a GitHub Release.
+EOF
+}
+
+VERSION=""
+TAG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      VERSION="$2"
+      shift 2
+      ;;
+    --tag)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      TAG="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+[[ -n "$VERSION" ]] || { echo "--version is required" >&2; exit 2; }
+[[ -n "$TAG" ]] || { echo "--tag is required" >&2; exit 2; }
+[[ "$TAG" == "v$VERSION" ]] || {
+  echo "release tag '$TAG' must be v$VERSION" >&2
+  exit 1
+}
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+cargo_version="$(awk -F '"' '/^version =/ { print $2; exit }' Cargo.toml)"
+cask_version="$(awk -F '"' '/^[[:space:]]*version / { print $2; exit }' Casks/aki.rb)"
+readme_badge="[![Version $VERSION](https://img.shields.io/badge/version-$VERSION-blue)](./Cargo.toml)"
+
+[[ "$cargo_version" == "$VERSION" ]] || {
+  echo "Cargo.toml version '$cargo_version' does not match $VERSION" >&2
+  exit 1
+}
+
+[[ "$cask_version" == "$VERSION" ]] || {
+  echo "Casks/aki.rb version '$cask_version' does not match $VERSION" >&2
+  exit 1
+}
+
+grep -Fq "$readme_badge" README.md || {
+  echo "README.md version badge does not match $VERSION" >&2
+  exit 1
+}
+
+grep -Eq "^## ${TAG}([[:space:]-]|$)" CHANGELOG.md || {
+  echo "CHANGELOG.md is missing a release section for $TAG" >&2
+  exit 1
+}
+
+grep -Fq "Aki-${VERSION}-macos.dmg" CHANGELOG.md || {
+  echo "CHANGELOG.md release section must link the Aki-${VERSION}-macos.dmg artifact" >&2
+  exit 1
+}
+
+grep -Fq "Aki-${VERSION}-macos.dmg.sha256" CHANGELOG.md || {
+  echo "CHANGELOG.md release section must link the Aki-${VERSION}-macos.dmg.sha256 artifact" >&2
+  exit 1
+}
+
+grep -Fq "releases/download/v#{version}/Aki-#{version}-macos.dmg" Casks/aki.rb || {
+  echo "Casks/aki.rb must point at the versioned GitHub Release DMG" >&2
+  exit 1
+}
+
+echo "release metadata ok: version=$VERSION tag=$TAG"

--- a/scripts/release_notes_from_changelog.sh
+++ b/scripts/release_notes_from_changelog.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/release_notes_from_changelog.sh --version VERSION --tag TAG
+
+Prints GitHub Release notes from the matching CHANGELOG.md section.
+EOF
+}
+
+VERSION=""
+TAG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      VERSION="$2"
+      shift 2
+      ;;
+    --tag)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      TAG="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+[[ -n "$VERSION" ]] || { echo "--version is required" >&2; exit 2; }
+[[ -n "$TAG" ]] || { echo "--tag is required" >&2; exit 2; }
+[[ "$TAG" == "v$VERSION" ]] || {
+  echo "release tag '$TAG' must be v$VERSION" >&2
+  exit 1
+}
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+section="$(
+  awk -v tag="$TAG" '
+    /^## / {
+      if (found) {
+        exit
+      }
+      if ($0 ~ "^## " tag "([[:space:]-]|$)") {
+        found = 1
+        next
+      }
+    }
+    found {
+      print
+    }
+  ' CHANGELOG.md
+)"
+
+if [[ -z "${section//[[:space:]]/}" ]]; then
+  echo "CHANGELOG.md has no notes for $TAG" >&2
+  exit 1
+fi
+
+cat <<EOF
+# Aki ${VERSION}
+
+${section}
+
+## Install
+
+\`\`\`console
+\$ brew tap gongahkia/aki
+\$ brew install --cask aki
+\`\`\`
+
+The cask installs the signed and notarized DMG attached to this release.
+EOF


### PR DESCRIPTION
Closes #32

## Summary
- add CHANGELOG.md with v0.1.0 release notes, tag convention, and install artifact links
- add release metadata and changelog-to-release-notes scripts
- update the macOS release workflow to validate version/tag metadata and publish notes from CHANGELOG.md
- link the changelog from README and release readiness docs

## Validation
- scripts/check_release_metadata.sh --version 0.1.0 --tag v0.1.0
- scripts/release_notes_from_changelog.sh --version 0.1.0 --tag v0.1.0
- bash -n scripts/check_release_metadata.sh scripts/release_notes_from_changelog.sh scripts/release_macos_dmg.sh
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release-macos.yml')"\n- git diff --cached --check