### PR TITLE
[codex] add cargo and nix install paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The TUI includes a local in-memory redaction log, with explicit export only. Its
 
 ## Install
 
+### macOS App
+
 The primary macOS release install path is the Homebrew cask:
 
 ```console
@@ -41,18 +43,45 @@ $ brew tap gongahkia/aki
 $ brew install --cask aki
 ```
 
-If the signed DMG for the current version has not been published yet, use the source install path:
+The cask installs the signed app bundle once the GitHub Release DMG exists for the current version.
+
+### Rust CLI From Source
+
+The CLI binary is named `aki`, but the workspace package is currently `privacy-tui`. `cargo install aki` from crates.io is not available until a crate is published, so install the package from Git:
 
 ```console
-$ brew install rust tesseract
-$ git clone https://github.com/gongahkia/aki
-$ cd aki
-$ cargo install --path privacy-tui
+$ brew install rust tesseract ffmpeg
+$ cargo install --git https://github.com/gongahkia/aki privacy-tui --locked
 $ aki self-test
 $ aki run
 ```
 
-If you do not want to install the binary yet, run the TUI directly from the workspace:
+For a local checkout, use the path install:
+
+```console
+$ git clone https://github.com/gongahkia/aki
+$ cd aki
+$ cargo install --path privacy-tui --locked
+$ aki self-test
+$ aki run
+```
+
+`ffmpeg` is only required for `aki redact` and direct MP4 output, but installing it up front keeps those commands available.
+
+### Nix CLI
+
+Nix users can run or install the CLI package from the flake:
+
+```console
+$ nix run github:gongahkia/aki#aki -- doctor
+$ nix profile install github:gongahkia/aki#aki
+```
+
+The Nix path is documented in [`docs/nix-install.md`](./docs/nix-install.md). It builds the Rust CLI from source and does not replace the signed macOS app cask.
+
+### Developer Workspace
+
+If you do not want to install the binary, run the TUI directly from the workspace:
 
 ```console
 $ cargo run -p privacy-tui -- run

--- a/docs/nix-install.md
+++ b/docs/nix-install.md
@@ -1,0 +1,51 @@
+# Nix Install
+
+The Nix path builds the Rust CLI binary named `aki` from source. It is useful for Nix users and CI-style development shells, but it is not the signed macOS app bundle. The primary macOS app install path remains the Homebrew cask after a signed and notarized DMG exists.
+
+## Run Without Installing
+
+From this repository:
+
+```console
+$ nix run .#aki -- doctor
+```
+
+From GitHub:
+
+```console
+$ nix run github:gongahkia/aki#aki -- doctor
+```
+
+Pin a specific revision for repeatable installs:
+
+```console
+$ nix run github:gongahkia/aki/<commit-sha>#aki -- --help
+```
+
+## Install To A Profile
+
+```console
+$ nix profile install github:gongahkia/aki#aki
+$ aki doctor
+```
+
+## Developer Shell
+
+```console
+$ nix develop
+$ cargo fmt --all -- --check
+$ cargo clippy --all-targets -- -D warnings
+$ cargo test --all
+```
+
+The flake shell includes Rust, Tesseract, ffmpeg, libclang, pkg-config, and the Linux or macOS native libraries needed by the workspace.
+
+## Validation
+
+When Nix is available, validate the package and app outputs with:
+
+```console
+$ nix flake check
+$ nix build .#aki
+$ result/bin/aki doctor
+```

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,141 @@
+{
+  description = "Aki local-first screen privacy filter";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+
+      forAllSystems = f:
+        nixpkgs.lib.genAttrs systems (system:
+          f system (import nixpkgs { inherit system; }));
+    in
+    {
+      packages = forAllSystems (system: pkgs:
+        let
+          lib = pkgs.lib;
+          frameworks =
+            if pkgs.stdenv.isDarwin
+            then pkgs.darwin.apple_sdk.frameworks
+            else { };
+          optionalFramework = name:
+            lib.optional
+              (pkgs.stdenv.isDarwin && lib.hasAttr name frameworks)
+              frameworks.${name};
+          darwinBuildInputs = lib.concatMap optionalFramework [
+            "Cocoa"
+            "CoreFoundation"
+            "CoreGraphics"
+            "CoreMedia"
+            "CoreVideo"
+            "ScreenCaptureKit"
+          ];
+          linuxBuildInputs = lib.optionals pkgs.stdenv.isLinux [
+            pkgs.pipewire
+            pkgs.xorg.libxcb
+          ];
+        in
+        rec {
+          aki = pkgs.rustPlatform.buildRustPackage {
+            pname = "aki";
+            version = "0.1.0";
+            src = ./.;
+
+            cargoLock.lockFile = ./Cargo.lock;
+            cargoBuildFlags = [ "-p" "privacy-tui" ];
+            cargoTestFlags = [ "--all" ];
+
+            nativeBuildInputs = [
+              pkgs.makeWrapper
+              pkgs.llvmPackages.libclang
+              pkgs.pkg-config
+            ];
+
+            buildInputs = [
+              pkgs.leptonica
+              pkgs.tesseract
+            ] ++ darwinBuildInputs ++ linuxBuildInputs;
+
+            nativeCheckInputs = [
+              pkgs.ffmpeg
+              pkgs.tesseract
+            ];
+
+            LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+
+            postInstall = ''
+              wrapProgram "$out/bin/aki" \
+                --prefix PATH : ${lib.makeBinPath [ pkgs.ffmpeg ]} \
+                --set-default TESSDATA_PREFIX "${pkgs.tesseract}/share/tessdata"
+            '';
+
+            meta = {
+              description = "Local-first real-time privacy filter for screen sharing and livestreaming";
+              homepage = "https://github.com/gongahkia/aki";
+              license = lib.licenses.mit;
+              mainProgram = "aki";
+            };
+          };
+
+          default = aki;
+        });
+
+      apps = forAllSystems (system: pkgs: {
+        aki = {
+          type = "app";
+          program = "${self.packages.${system}.aki}/bin/aki";
+        };
+        default = self.apps.${system}.aki;
+      });
+
+      devShells = forAllSystems (system: pkgs:
+        let
+          lib = pkgs.lib;
+          frameworks =
+            if pkgs.stdenv.isDarwin
+            then pkgs.darwin.apple_sdk.frameworks
+            else { };
+          optionalFramework = name:
+            lib.optional
+              (pkgs.stdenv.isDarwin && lib.hasAttr name frameworks)
+              frameworks.${name};
+        in
+        {
+          default = pkgs.mkShell {
+            packages = [
+              pkgs.cargo
+              pkgs.clippy
+              pkgs.ffmpeg
+              pkgs.llvmPackages.libclang
+              pkgs.pkg-config
+              pkgs.rustc
+              pkgs.rustfmt
+              pkgs.tesseract
+            ]
+            ++ lib.optionals pkgs.stdenv.isLinux [
+              pkgs.pipewire
+              pkgs.xorg.libxcb
+            ]
+            ++ lib.concatMap optionalFramework [
+              "Cocoa"
+              "CoreFoundation"
+              "CoreGraphics"
+              "CoreMedia"
+              "CoreVideo"
+              "ScreenCaptureKit"
+            ];
+
+            LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+            TESSDATA_PREFIX = "${pkgs.tesseract}/share/tessdata";
+          };
+        });
+    };
+}


### PR DESCRIPTION
Closes #34

## Summary
- split README install docs into macOS app, Rust CLI, Nix CLI, and developer workspace paths
- document why `cargo install aki` is not available yet and provide working Git/local Cargo install commands for the `privacy-tui` package
- add a Nix flake package/app/dev shell and Nix install guide

## Validation
- cargo install --path privacy-tui --locked --root <tmp> && <tmp>/bin/aki --help
- cargo install --git https://github.com/gongahkia/aki privacy-tui --locked --root <tmp> && <tmp>/bin/aki --help
- cargo test --all
- git diff --check

## Not run
- nix flake check: Nix is not installed in this environment